### PR TITLE
Created a 2nd metamake.sh file (metamake_MPI.sh) which will link an MPI library to GOMC

### DIFF
--- a/CMake/GOMCCPUSetup.cmake
+++ b/CMake/GOMCCPUSetup.cmake
@@ -7,6 +7,9 @@ if(ENSEMBLE_NVT)
       #needed for hostname
       target_link_libraries(NVT ws2_32)
    endif()
+   if(MPI_FOUND)
+      target_link_libraries(NVT ${MPI_LIBRARIES})
+   endif()
 endif()
 
 if(ENSEMBLE_GEMC)
@@ -17,6 +20,9 @@ if(ENSEMBLE_GEMC)
    if(WIN32)
       #needed for hostname
       target_link_libraries(GEMC ws2_32)
+   endif()
+   if(MPI_FOUND)
+      target_link_libraries(GEMC ${MPI_LIBRARIES})
    endif()
 endif()
 
@@ -29,6 +35,9 @@ if(ENSEMBLE_GCMC)
       #needed for hostname
       target_link_libraries(GCMC ws2_32)
    endif()
+   if(MPI_FOUND)
+      target_link_libraries(GCMC ${MPI_LIBRARIES})
+   endif()
 endif()
 
 if(ENSEMBLE_NPT)
@@ -39,6 +48,9 @@ if(ENSEMBLE_NPT)
    if(WIN32)
       #needed for hostname
       target_link_libraries(NPT ws2_32)
+   endif()
+   if(MPI_FOUND)
+      target_link_libraries(NPT ${MPI_LIBRARIES})
    endif()
 endif()
 

--- a/CMake/GOMCCUDASetup.cmake
+++ b/CMake/GOMCCUDASetup.cmake
@@ -29,6 +29,9 @@ if(ENSEMBLE_GPU_NVT)
         #needed for hostname
         target_link_libraries(GPU_NVT ws2_32)
     endif()
+    if(MPI_FOUND)
+      target_link_libraries(NVT ${MPI_LIBRARIES})
+   endif()
 endif()
 
 if(ENSEMBLE_GPU_GEMC)
@@ -41,6 +44,9 @@ if(ENSEMBLE_GPU_GEMC)
         #needed for hostname
         target_link_libraries(GPU_GEMC ws2_32)
     endif()
+    if(MPI_FOUND)
+      target_link_libraries(GEMC ${MPI_LIBRARIES})
+   endif()
 endif()
 
 if(ENSEMBLE_GPU_GCMC)
@@ -53,6 +59,9 @@ if(ENSEMBLE_GPU_GCMC)
         #needed for hostname
         target_link_libraries(GPU_GCMC ws2_32)
     endif()
+    if(MPI_FOUND)
+      target_link_libraries(GCMC ${MPI_LIBRARIES})
+   endif()
 endif()
 
 if(ENSEMBLE_GPU_NPT)
@@ -65,4 +74,7 @@ if(ENSEMBLE_GPU_NPT)
         #needed for hostname
         target_link_libraries(GPU_NPT ws2_32)
     endif()
+    if(MPI_FOUND)
+      target_link_libraries(NPT ${MPI_LIBRARIES})
+   endif()
 endif()

--- a/CMake/GOMCManageMPI.cmake
+++ b/CMake/GOMCManageMPI.cmake
@@ -1,0 +1,176 @@
+#
+# This file is part of the GROMACS molecular simulation package.
+#
+# Copyright (c) 2012,2013,2014,2015,2016,2019, by the GROMACS development team, led by
+# Mark Abraham, David van der Spoel, Berk Hess, and Erik Lindahl,
+# and including many others, as listed in the AUTHORS file in the
+# top-level source directory and at http://www.gromacs.org.
+#
+# GROMACS is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# GROMACS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with GROMACS; if not, see
+# http://www.gnu.org/licenses, or write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+#
+# If you want to redistribute modifications to GROMACS, please
+# consider that scientific software is very special. Version
+# control is crucial - bugs must be traceable. We will be happy to
+# consider code for inclusion in the official distribution, but
+# derived work must not be called official GROMACS. Details are found
+# in the README & COPYING files - if they are missing, get the
+# official version at http://www.gromacs.org.
+#
+# To help us fund GROMACS development, we humbly ask that you cite
+# the research papers on the package. Check out http://www.gromacs.org.
+
+# Manage the MPI setup, assuming that CMAKE_C_COMPILER is an MPI
+# (wrapper) compiler.
+if(GOMC_MPI)
+  if(GOMC_THREAD_MPI)
+    message(STATUS "MPI is not compatible with thread-MPI. Disabling thread-MPI.")
+    set(GOMC_THREAD_MPI OFF CACHE BOOL
+        "Build a thread-MPI-based multithreaded version of GROMACS (not compatible with MPI)" FORCE)
+  endif()
+
+  # Test the CMAKE_C_COMPILER for being an MPI (wrapper) compiler
+  TRY_COMPILE(MPI_FOUND ${CMAKE_BINARY_DIR}
+    "${CMAKE_SOURCE_DIR}/CMake/TestMPI.cpp"
+    COMPILE_DEFINITIONS )
+
+  # If CMAKE_C_COMPILER is not a MPI wrapper. Try to find MPI using cmake module as fall-back.
+  if(NOT MPI_FOUND)
+      find_package(MPI)
+      if(MPI_C_FOUND)
+          set(MPI_COMPILE_FLAGS ${MPI_C_COMPILE_FLAGS})
+          set(MPI_LINKER_FLAGS ${MPI_C_LINK_FLAGS})
+          include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
+          list(APPEND GOMC_COMMON_LIBRARIES ${MPI_C_LIBRARIES})
+      endif()
+      set(MPI_FOUND ${MPI_C_FOUND})
+  else()
+      # The following defaults are based on FindMPI.cmake in cmake
+      # 3.1.2. (That package does not actually do any detection of the
+      # flags, but if it ever does then we should re-visit how we use
+      # the package.) If we are compiling with an MPI wrapper
+      # compiler, then MPI_FOUND will be set above, and will mean that
+      # none of these cache variables are populated by the package. We
+      # need to do it manually so that test drivers can work using the
+      # standard machinery for CMake + FindMPI.cmake.  Users will need
+      # to set these to suit their MPI setup in order for tests to
+      # work.
+
+      find_program(MPIEXEC
+          NAMES mpiexec mpirun lamexec srun aprun poe
+          HINTS ${MPI_HOME} $ENV{MPI_HOME}
+          PATH_SUFFIXES bin
+          DOC "Executable for running MPI programs.")
+
+      set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "Flag used by MPI to specify the number of processes for MPIEXEC; the next option will be the number of processes.")
+      set(MPIEXEC_PREFLAGS     ""    CACHE STRING "These flags will be directly before the executable that is being run by MPIEXEC.")
+      set(MPIEXEC_POSTFLAGS    ""    CACHE STRING "These flags will come after all flags given to MPIEXEC.")
+      set(MPIEXEC_MAX_NUMPROCS "2"   CACHE STRING "Maximum number of processors available to run MPI applications.")
+      mark_as_advanced(MPIEXEC MPIEXEC_NUMPROC_FLAG MPIEXEC_PREFLAGS MPIEXEC_POSTFLAGS MPIEXEC_MAX_NUMPROCS)
+  endif()
+
+  if(MPI_FOUND)
+    include(${PROJECT_SOURCE_DIR}/CMake/GOMCTestMPI_IN_PLACE.cmake)
+    if (GOMC_MPI_IN_PLACE)
+      GOMC_test_mpi_in_place(MPI_IN_PLACE_EXISTS)
+    endif()
+
+    # Find path of the mpi compilers
+    if (${MPI_C_FOUND})
+        get_filename_component(_mpi_c_compiler_path "${MPI_C_COMPILER}" PATH)
+        get_filename_component(_mpiexec_path "${MPIEXEC}" PATH)
+    else()
+        get_filename_component(_cmake_c_compiler_path "${CMAKE_C_COMPILER}" PATH)
+        get_filename_component(_cmake_cxx_compiler_path "${CMAKE_CXX_COMPILER}" PATH)
+    endif()
+
+    # Test for and warn about unsuitable MPI versions
+    #
+    # Execute the ompi_info binary with the full path of the compiler wrapper
+    # found, otherwise we run the risk of false positives.
+    find_file(MPI_INFO_BIN ompi_info
+              HINTS ${_mpi_c_compiler_path} ${_mpiexec_path}
+                    ${_cmake_c_compiler_path} ${_cmake_cxx_compiler_path}
+              NO_DEFAULT_PATH
+              NO_SYSTEM_ENVIRONMENT_PATH
+              NO_CMAKE_SYSTEM_PATH)
+    if (MPI_INFO_BIN)
+      exec_program(${MPI_INFO_BIN}
+        ARGS -v ompi full
+        OUTPUT_VARIABLE OPENMPI_TYPE
+        RETURN_VALUE OPENMPI_EXEC_RETURN)
+      if(OPENMPI_EXEC_RETURN EQUAL 0)
+        string(REGEX REPLACE ".*Open MPI: \([0-9]+\\.[0-9]*\\.?[0-9]*\).*" "\\1" OPENMPI_VERSION ${OPENMPI_TYPE})
+        if(OPENMPI_VERSION VERSION_LESS "1.4.1")
+          MESSAGE(WARNING
+             "CMake found OpenMPI version ${OPENMPI_VERSION} on your system. "
+             "There are known problems with GROMACS and OpenMPI version < 1.4.1. "
+             "Please consider updating your OpenMPI if your MPI wrapper compilers "
+             "are using the above OpenMPI version.")
+        endif()
+        if(OPENMPI_VERSION VERSION_EQUAL "1.8.6")
+          MESSAGE(WARNING
+             "CMake found OpenMPI version ${OPENMPI_VERSION} on your system. "
+             "This OpenMPI version is known to leak memory with GROMACS,"
+             "please update to a more recent version. ")
+        endif()
+        unset(OPENMPI_VERSION)
+        unset(OPENMPI_TYPE)
+        unset(OPENMPI_EXEC_RETURN)
+      endif()
+    endif()
+    unset(MPI_INFO_BIN CACHE)
+
+    # Execute the mpiname binary with the full path of the compiler wrapper
+    # found, otherwise we run the risk of false positives.
+    find_file(MPINAME_BIN mpiname
+              HINTS ${_mpi_c_compiler_path}
+                    ${_cmake_c_compiler_path} ${_cmake_cxx_compiler_path}
+              NO_DEFAULT_PATH
+              NO_SYSTEM_ENVIRONMENT_PATH
+              NO_CMAKE_SYSTEM_PATH)
+    if (MPINAME_BIN)
+      exec_program(${MPINAME_BIN}
+        ARGS -n -v
+        OUTPUT_VARIABLE MVAPICH2_TYPE
+        RETURN_VALUE MVAPICH2_EXEC_RETURN)
+      if(MVAPICH2_EXEC_RETURN EQUAL 0)
+        string(REGEX MATCH "MVAPICH2" MVAPICH2_NAME ${MVAPICH2_TYPE})
+        # Want to check for MVAPICH2 in case some other library supplies mpiname
+        string(REGEX REPLACE "MVAPICH2 \([0-9]+\\.[0-9]*[a-z]?\\.?[0-9]*\)" "\\1" MVAPICH2_VERSION ${MVAPICH2_TYPE})
+        if(${MVAPICH2_NAME} STREQUAL "MVAPICH2" AND MVAPICH2_VERSION VERSION_LESS "1.5")
+          # This test works correctly even with 1.5a1
+          MESSAGE(WARNING
+             "CMake found MVAPICH2 version ${MVAPICH2_VERSION} on your system. "
+             "There are known problems with GROMACS and MVAPICH2 version < 1.5. "
+             "Please consider updating your MVAPICH2 if your MPI wrapper compilers "
+             "are using the above MVAPICH2 version.")
+       endif()
+       unset(MVAPICH2_VERSION)
+       unset(MVAPICH2_NAME)
+       unset(MVAPICH2_TYPE)
+       unset(MVAPICH2_EXEC_RETURN)
+      endif()
+    endif()
+    unset(MPINAME_BIN CACHE)
+  else()
+      message(FATAL_ERROR
+        "MPI support requested, but no MPI compiler found. Either set the "
+        "C-compiler (CMAKE_C_COMPILER) to the MPI compiler (often called mpicc), "
+        "or set the variables reported missing for MPI_C above.")
+  endif()
+
+  set(GOMC_LIB_MPI 1)
+endif()

--- a/CMake/GOMCOptionUtilities.cmake
+++ b/CMake/GOMCOptionUtilities.cmake
@@ -1,0 +1,231 @@
+#
+# This file is part of the GROMACS molecular simulation package.
+#
+# Copyright (c) 2013,2014,2015,2017, by the GROMACS development team, led by
+# Mark Abraham, David van der Spoel, Berk Hess, and Erik Lindahl,
+# and including many others, as listed in the AUTHORS file in the
+# top-level source directory and at http://www.gromacs.org.
+#
+# GROMACS is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# GROMACS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with GROMACS; if not, see
+# http://www.gnu.org/licenses, or write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+#
+# If you want to redistribute modifications to GROMACS, please
+# consider that scientific software is very special. Version
+# control is crucial - bugs must be traceable. We will be happy to
+# consider code for inclusion in the official distribution, but
+# derived work must not be called official GROMACS. Details are found
+# in the README & COPYING files - if they are missing, get the
+# official version at http://www.gromacs.org.
+#
+# To help us fund GROMACS development, we humbly ask that you cite
+# the research papers on the package. Check out http://www.gromacs.org.
+
+# Helper functions for managing more complex options
+#
+
+# Creates a string cache variable with multiple choices
+#
+# Usage:
+#   GOMC_option_multichoice(VAR "Description" DEFAULT_VALUE
+#                          Value1 Value2 ... ValueN)
+# Output:
+#   VAR is set in the cache and in the caller's scope. The caller can assume
+#   that it is always one of the provided values, converted to uppercase.
+#
+# Main benefit is that the list of allowed values only needs to be provided
+# once, and gets used in multiple contexts:
+#   1. It is automatically added to the description.
+#   2. It is set as the STRINGS property of the created cache variable for use
+#      with CMake GUIs.
+#   3. The user-provided value is checked against the list, and a fatal error
+#      is produced if the value is not known.  The caller does not need to
+#      produce good error messages in cases where it may be necessary to check
+#      for the validity again.
+# As a special case, any "[built-in]" string in the allowed values is ignored
+# when checking the user-provided value, but is added to all user-visible
+# messages.
+#
+# It appears that ccmake does not use the STRINGS property, but perhaps some
+# day...
+#
+function(GOMC_OPTION_MULTICHOICE NAME DESCRIPTION DEFAULT)
+    # Some processing of the input values
+    string(REPLACE ";" ", " _allowed_comma_separated "${ARGN}")
+    set(_description "${DESCRIPTION}. Pick one of: ${_allowed_comma_separated}")
+    string(REPLACE "[built-in]" "" _allowed "${ARGN}")
+
+    # Set the cache properties
+    set(${NAME} ${DEFAULT} CACHE STRING "${_description}")
+    set_property(CACHE ${NAME} PROPERTY STRINGS ${_allowed})
+
+    # Check that the value is one of the allowed
+    set(_org_value "${${NAME}}")
+    string(TOUPPER "${${NAME}}" ${NAME})
+    string(TOUPPER "${_allowed}" _allowed_as_upper)
+    list(FIND _allowed_as_upper "${${NAME}}" _found_index)
+    if (_found_index EQUAL -1)
+        message(FATAL_ERROR "Invalid value for ${NAME}: ${_org_value}.  "
+                            "Pick one of: ${_allowed_comma_separated}")
+    endif()
+    # Always provide the upper-case value to the caller
+    set(${NAME} "${${NAME}}" PARENT_SCOPE)
+endfunction()
+
+# Convenience function for reporting a fatal error for an invalid input value
+function(GOMC_INVALID_OPTION_VALUE NAME)
+    message(FATAL_ERROR "Invalid value for ${NAME}: ${${NAME}}")
+endfunction()
+
+# Declares a cache variable with ON/OFF/AUTO values
+#
+# Usage:
+#   GOMC_option_trivalue(VAR "Description" DEFAULT)
+#
+# Output:
+#   VAR is created in the cache, and the caller can assume that the value is
+#   always one of ON/OFF/AUTO.  Additionally, VAR_AUTO is set if value is AUTO,
+#   and VAR_FORCE is set if value is ON.
+#   These make it convenient to check for any combination of states with simple
+#   if() statements (simple if(VAR) matches AUTO and ON).
+function(GOMC_OPTION_TRIVALUE NAME DESCRIPTION DEFAULT)
+    set(_description "${DESCRIPTION}. ON/OFF/AUTO")
+    set(${NAME} ${DEFAULT} CACHE STRING "${_description}")
+    set_property(CACHE ${NAME} PROPERTY STRINGS ON OFF AUTO)
+
+    set(${NAME}_AUTO OFF)
+    set(${NAME}_FORCE OFF)
+    string(TOUPPER "${${NAME}}" ${NAME})
+    if ("${${NAME}}" STREQUAL "AUTO")
+        set(${NAME}_AUTO ON)
+    elseif (${NAME})
+        set(${NAME}_FORCE ON)
+        set(${NAME} ON)
+    else()
+        set(${NAME} OFF)
+    endif()
+    # Always provide the sanitized value to the caller
+    set(${NAME}       "${${NAME}}"       PARENT_SCOPE)
+    set(${NAME}_AUTO  "${${NAME}_AUTO}"  PARENT_SCOPE)
+    set(${NAME}_FORCE "${${NAME}_FORCE}" PARENT_SCOPE)
+endfunction()
+
+# Hides or shows a cache value based on conditions
+#
+# Usage:
+#   GOMC_add_cache_dependency(VAR TYPE CONDITIONS VALUE)
+# where
+#   VAR        is a name of a cached variable
+#   TYPE       is the type of VAR
+#   CONDITIONS is a list of conditional expressions (see below)
+#   VALUE      is a value that is set to VAR if CONDITIONS is not satisfied
+#
+# Evaluates each condition in CONDITIONS, and if any of them is false,
+# VAR is marked internal (hiding it from the user) and its value is set to
+# VALUE.  The previous user-set value of VAR is still remembered in the cache,
+# and used when CONDITIONS become true again.
+#
+# The conditions is a semicolon-separated list of conditions as specified for
+# CMake if() statements, such as "GOMC_FFT_LIBRARY STREQUAL FFTW3",
+# "NOT GOMC_MPI" or "GOMC_MPI;NOT GOMC_DOUBLE".  Note that quotes within the
+# expressions don't work for some reason (even if escaped).
+#
+# The logic is adapted from cmake_dependent_option().
+#
+function(GOMC_ADD_CACHE_DEPENDENCY NAME TYPE CONDITIONS FORCED_VALUE)
+    set(_available TRUE)
+    foreach(_cond ${CONDITIONS})
+        string(REGEX REPLACE " +" ";" _cond_as_list ${_cond})
+        if (${_cond_as_list})
+        else()
+            set(_available FALSE)
+        endif()
+    endforeach()
+    if (_available)
+        set_property(CACHE ${NAME} PROPERTY TYPE ${TYPE})
+    else()
+        set(${NAME} "${FORCED_VALUE}" PARENT_SCOPE)
+        set_property(CACHE ${NAME} PROPERTY TYPE INTERNAL)
+    endif()
+endfunction()
+
+# Works like cmake_dependent_option(), but allows for an arbitrary cache value
+# instead of only an ON/OFF option
+#
+# Usage:
+#   GOMC_dependent_cache_variable(VAR "Description" TYPE DEFAULT CONDITIONS)
+#
+# Creates a cache variable VAR with the given description, type and default
+# value.  If any of the conditions listed in CONDITIONS is not true, then
+# the cache variable is marked internal (hiding it from the user) and the
+# value of VAR is set to DEFAULT.  The previous user-set value of VAR is still
+# remembered in the cache, and used when CONDITIONS become true again.
+# Any further changes to the variable can be done with simple set()
+# (or set_property(CACHE VAR PROPERTY VALUE ...) if the cache needs to be
+# modified).
+#
+# See GOMC_add_cache_dependency() on how to specify the conditions.
+#
+macro(GOMC_DEPENDENT_CACHE_VARIABLE NAME DESCRIPTION TYPE DEFAULT CONDITIONS)
+    set(${NAME} "${DEFAULT}" CACHE ${TYPE} "${DESCRIPTION}")
+    GOMC_add_cache_dependency(${NAME} ${TYPE} "${CONDITIONS}" "${DEFAULT}")
+endmacro()
+
+# Works like cmake_dependent_option(), but reuses the code from
+# GOMC_dependent_cache_variable() to make sure both behave the same way.
+macro(GOMC_DEPENDENT_OPTION NAME DESCRIPTION DEFAULT CONDITIONS)
+    GOMC_dependent_cache_variable(${NAME} "${DESCRIPTION}" BOOL "${DEFAULT}" "${CONDITIONS}")
+endmacro()
+
+# Sets a boolean variable based on conditions
+#
+# Usage:
+#   GOMC_set_boolean(VAR CONDITIONS)
+#
+# Sets VAR to ON if all conditions listed in CONDITIONS are true, otherwise
+# VAR is set OFF.
+#
+# See GOMC_add_cache_dependency() on how to specify the conditions.
+#
+function (GOMC_SET_BOOLEAN NAME CONDITIONS)
+    set(${NAME} ON)
+    foreach(_cond ${CONDITIONS})
+        string(REGEX REPLACE " +" ";" _cond_as_list ${_cond})
+        if (${_cond_as_list})
+        else()
+            set(${NAME} OFF)
+        endif()
+    endforeach()
+    set(${NAME} ${${NAME}} PARENT_SCOPE)
+endfunction()
+
+# Checks if one or more variables have changed since last call to this function
+#
+# Usage:
+#   GOMC_check_if_changed(RESULT VAR1 VAR2 ... VARN)
+#
+# Sets RESULT to true if any of the given variables VAR1 ... VARN has
+# changed since the last call to this function for that variable.
+# Changes are tracked also across CMake runs.
+function(GOMC_CHECK_IF_CHANGED RESULT)
+    set(_result FALSE)
+    foreach (_var ${ARGN})
+        if (NOT "${${_var}}" STREQUAL "${${_var}_PREVIOUS_VALUE}")
+            set(_result TRUE)
+        endif()
+        set(${_var}_PREVIOUS_VALUE "${${_var}}" CACHE INTERNAL
+            "Previous value of ${_var} for change tracking")
+    endforeach()
+    set(${RESULT} ${_result} PARENT_SCOPE)
+endfunction()

--- a/CMake/GOMCTestMPI_IN_PLACE.cmake
+++ b/CMake/GOMCTestMPI_IN_PLACE.cmake
@@ -1,0 +1,74 @@
+#
+# This file is part of the GROMACS molecular simulation package.
+#
+# Copyright (c) 2009,2011,2012,2014,2015,2016, by the GROMACS development team, led by
+# Mark Abraham, David van der Spoel, Berk Hess, and Erik Lindahl,
+# and including many others, as listed in the AUTHORS file in the
+# top-level source directory and at http://www.gromacs.org.
+#
+# GROMACS is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# GROMACS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with GROMACS; if not, see
+# http://www.gnu.org/licenses, or write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+#
+# If you want to redistribute modifications to GROMACS, please
+# consider that scientific software is very special. Version
+# control is crucial - bugs must be traceable. We will be happy to
+# consider code for inclusion in the official distribution, but
+# derived work must not be called official GROMACS. Details are found
+# in the README & COPYING files - if they are missing, get the
+# official version at http://www.gromacs.org.
+#
+# To help us fund GROMACS development, we humbly ask that you cite
+# the research papers on the package. Check out http://www.gromacs.org.
+
+# - Define macro to check if MPI_IN_PLACE exists
+#
+#  GOMC_TEST_MPI_IN_PLACE(VARIABLE)
+#
+#  VARIABLE will be set to true if MPI_IN_PLACE exists
+#
+
+include(CheckCSourceCompiles)
+MACRO(GOMC_TEST_MPI_IN_PLACE VARIABLE)
+  if(NOT DEFINED MPI_IN_PLACE_COMPILE_OK)
+    MESSAGE(STATUS "Checking for MPI_IN_PLACE")
+
+    set(CMAKE_REQUIRED_FLAGS ${MPI_COMPILE_FLAGS})
+    set(CMAKE_REQUIRED_INCLUDES ${MPI_INCLUDE_PATH})
+    set(CMAKE_REQUIRED_LIBRARIES ${MPI_LIBRARIES})
+    check_cxx_source_compiles(
+      "#include <mpi.h>
+int main(void) {
+  void* buf;
+  MPI_Allreduce(MPI_IN_PLACE, buf, 10, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+}" MPI_IN_PLACE_COMPILE_OK)
+
+    if(MPI_IN_PLACE_COMPILE_OK)
+        MESSAGE(STATUS "Checking for MPI_IN_PLACE - yes")
+    else()
+        MESSAGE(STATUS "Checking for MPI_IN_PLACE - no")
+    endif()
+    set(MPI_IN_PLACE_COMPILE_OK "${MPI_IN_PLACE_COMPILE_OK}" CACHE INTERNAL "Result of mpi_in_place check")
+    set(CMAKE_REQUIRED_FLAGS)
+    set(CMAKE_REQUIRED_INCLUDES)
+    set(CMAKE_REQUIRED_LIBRARIES)
+  endif()
+  if (MPI_IN_PLACE_COMPILE_OK)
+    set(${VARIABLE} ${MPI_IN_PLACE_COMPILE_OK}
+      "Result of test for MPI_IN_PLACE")
+  endif()
+ENDMACRO(GOMC_TEST_MPI_IN_PLACE VARIABLE)
+
+
+

--- a/CMake/TestMPI.cpp
+++ b/CMake/TestMPI.cpp
@@ -1,0 +1,6 @@
+#include <mpi.h> 
+
+int main(int argc, char **argv)
+{
+  MPI_Init(&argc,&argv);
+}

--- a/CMake/TestWinProcNum.cpp
+++ b/CMake/TestWinProcNum.cpp
@@ -1,0 +1,7 @@
+#define _WIN32_WINNT 0x0601 /*Require Windows7 (needed for MingW)*/
+#include <windows.h>
+int main()
+{
+    PROCESSOR_NUMBER p;
+    return 0;
+}

--- a/CMake/ThreadMPI.cmake
+++ b/CMake/ThreadMPI.cmake
@@ -1,0 +1,205 @@
+# This source code file is part of thread_mpi.
+# Written by Sander Pronk, Erik Lindahl, and possibly others.
+#
+# Copyright (c) 2009, Sander Pronk, Erik Lindahl.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1) Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# 2) Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 3) Neither the name of the copyright holders nor the
+# names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY US ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL WE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# If you want to redistribute modifications, please consider that
+# scientific software is very special. Version control is crucial -
+# bugs must be traceable. We will be happy to consider code for
+# inclusion in the official distribution, but derived work should not
+# be called official thread_mpi. Details are found in the README & COPYING
+# files.
+
+include(CheckIncludeFileCXX)
+include(CheckCXXSymbolExists)
+include(CheckCXXSourceCompiles)
+
+# sets TMPI_ATOMICS to 1 if atomic operations are found, unset otherwise
+# Options:
+# include directory for thread_mpi/atomic.h
+MACRO(TMPI_TEST_ATOMICS INCDIR)
+
+    if (NOT DEFINED TMPI_ATOMICS)
+        try_compile(TEST_ATOMICS "${CMAKE_BINARY_DIR}"
+                "${CMAKE_SOURCE_DIR}/CMake/TestAtomics.cpp"
+                COMPILE_DEFINITIONS "-I${INCDIR} -DTMPI_ATOMICS")
+        if (TEST_ATOMICS)
+            message(STATUS "Atomic operations found")
+            # If the check fails, we want to be able to check again,
+            # in case the user has been able to fix this without
+            # needing to delete the cache. Thus we only cache
+            # positive results.
+            set(TMPI_ATOMICS ${TEST_ATOMICS} CACHE INTERNAL "Whether atomic operations are found")
+            set(TMPI_ATOMICS_INCDIR ${INCDIR} CACHE INTERNAL "Atomic operations check include dir")
+        else ()
+            message(STATUS "Atomic operations not found")
+            unset(TEST_ATOMICS)
+        endif()
+    endif()
+
+ENDMACRO(TMPI_TEST_ATOMICS VARIABLE)
+
+try_compile(HAVE_PROCESSOR_NUMBER ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/CMake/TestWinProcNum.cpp")
+
+include(FindThreads)
+
+if(CMAKE_USE_WIN32_THREADS_INIT AND NOT HAVE_PROCESSOR_NUMBER)
+    message(WARNING "Incomplete Windows Processor Group API. If you want GROMACS to be able to set thread affinity, choose a Mingw distribution with a complete API (e.g. Mingw-w64).")
+endif()
+
+if (CMAKE_USE_WIN32_THREADS_INIT AND HAVE_PROCESSOR_NUMBER)
+    set(THREAD_WINDOWS 1)
+    set(THREAD_LIB)
+elseif (CMAKE_USE_PTHREADS_INIT)
+    check_include_file_cxx(pthread.h    HAVE_PTHREAD_H)
+    set(THREAD_PTHREADS 1)
+    set(THREAD_LIB ${CMAKE_THREAD_LIBS_INIT})
+else()
+    message(FATAL_ERROR "Thread support required")
+endif ()
+
+# Turns on thread_mpi core threading functions.
+MACRO(TMPI_ENABLE_CORE INCDIR)
+    TMPI_TEST_ATOMICS(${INCDIR})
+
+# affinity checks
+    include(CheckFunctionExists)
+    if (THREAD_PTHREADS)
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+        # check for sched_setaffinity
+        check_cxx_source_compiles(
+            "#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+    int main(void) { cpu_set_t set;
+        CPU_ZERO(&set);
+        CPU_SET(0, &set);
+        pthread_setaffinity_np(pthread_self(), sizeof(set), &set);
+        return 0;
+    }"
+            PTHREAD_SETAFFINITY
+        )
+        if (PTHREAD_SETAFFINITY)
+            set(HAVE_PTHREAD_SETAFFINITY 1)
+        endif ()
+        set(CMAKE_REQUIRED_LIBRARIES)
+    endif ()
+
+
+# this runs on POSIX systems
+    check_include_file_cxx(unistd.h             HAVE_UNISTD_H)
+    check_include_file_cxx(sched.h              HAVE_SCHED_H)
+    check_include_file_cxx(sys/time.h           HAVE_SYS_TIME_H)
+    check_cxx_symbol_exists(sysconf    unistd.h HAVE_SYSCONF)
+# this runs on windows
+#check_include_files(windows.h		HAVE_WINDOWS_H)
+ENDMACRO(TMPI_ENABLE_CORE)
+
+# enable C++ library build.
+set(TMPI_CXX_LIB 1)
+
+# Turns on thread_mpi MPI functions.
+MACRO(TMPI_ENABLE)
+    TMPI_TEST_ATOMICS(TMPI_ATOMICS_INCDIR)
+    if(NOT DEFINED TMPI_ATOMICS)
+        message(WARNING "Atomic operations not found for this CPU+compiler combination. Thread support will be unbearably slow: disable threads. Atomic operations should work on all but the most obscure CPU+compiler combinations; if your system is not obscure -- like, for example, x86 with gcc --  please contact the developers.")
+    endif()
+
+    set(TMPI_ENABLED 1)
+
+# the spin-waiting option
+    option(THREAD_MPI_WAIT_FOR_NO_ONE "Use busy waits without yielding to the OS scheduler. Turning this on might improve performance (very) slightly at the cost of very poor performance if the threads are competing for CPU time." OFF)
+    mark_as_advanced(THREAD_MPI_WAIT_FOR_NO_ONE)
+    if (THREAD_MPI_WAIT_FOR_NO_ONE)
+        set(TMPI_WAIT_FOR_NO_ONE 1)
+    else ()
+        set(TMPI_WAIT_FOR_NO_ONE 0)
+    endif ()
+
+# the copy buffer option
+    option(THREAD_MPI_COPY_BUFFER "Use an intermediate copy buffer for small message sizes, to allow blocking sends to return quickly. Only useful in programs with relatively uncoupled threads (infrequent MPI communication)" OFF)
+    mark_as_advanced(THREAD_MPI_COPY_BUFFER)
+    if (THREAD_MPI_COPY_BUFFER)
+        set(TMPI_COPY_BUFFER 1)
+    else ()
+        set(TMPI_COPY_BUFFER 0)
+    endif ()
+
+# the profiling option
+    option(THREAD_MPI_PROFILING "Turn on simple MPI profiling." OFF)
+    mark_as_advanced(THREAD_MPI_PROFILING)
+    if (THREAD_MPI_PROFILING)
+        set(TMPI_PROFILE 1)
+    else ()
+        set(TMPI_PROFILE 0)
+    endif ()
+
+# tmpi warnings for testing
+    option(THREAD_MPI_WARNINGS "Turn thread_mpi warnings for testing." OFF)
+    mark_as_advanced(THREAD_MPI_WARNINGS)
+    if (THREAD_MPI_WARNINGS)
+        set(TMPI_WARNINGS 1)
+    else ()
+        set(TMPI_WARNINGS 0)
+    endif ()
+ENDMACRO(TMPI_ENABLE)
+
+
+MACRO(TMPI_GET_SOURCE_LIST SRC_VARIABLE SRC_ROOT)
+    set(${SRC_VARIABLE}
+        ${SRC_ROOT}/errhandler.cpp
+        ${SRC_ROOT}/tmpi_malloc.cpp
+        ${SRC_ROOT}/atomic.cpp
+        ${SRC_ROOT}/lock.cpp)
+
+    if (THREAD_PTHREADS)
+        list(APPEND ${SRC_VARIABLE} ${SRC_ROOT}/pthreads.cpp)
+    elseif (THREAD_WINDOWS)
+        list(APPEND ${SRC_VARIABLE} ${SRC_ROOT}/winthreads.cpp)
+    endif ()
+
+    if (TMPI_CXX_LIB)
+        list(APPEND ${SRC_VARIABLE} ${SRC_ROOT}/system_error.cpp)
+    endif ()
+
+    if (TMPI_ENABLED)
+        list(APPEND ${SRC_VARIABLE}
+             ${SRC_ROOT}/alltoall.cpp      ${SRC_ROOT}/p2p_protocol.cpp
+             ${SRC_ROOT}/barrier.cpp       ${SRC_ROOT}/p2p_send_recv.cpp
+             ${SRC_ROOT}/bcast.cpp         ${SRC_ROOT}/p2p_wait.cpp
+             ${SRC_ROOT}/collective.cpp    ${SRC_ROOT}/profile.cpp
+             ${SRC_ROOT}/comm.cpp          ${SRC_ROOT}/reduce.cpp
+             ${SRC_ROOT}/event.cpp         ${SRC_ROOT}/reduce_fast.cpp
+             ${SRC_ROOT}/gather.cpp        ${SRC_ROOT}/scatter.cpp
+             ${SRC_ROOT}/group.cpp         ${SRC_ROOT}/tmpi_init.cpp
+             ${SRC_ROOT}/topology.cpp      ${SRC_ROOT}/list.cpp
+             ${SRC_ROOT}/type.cpp          ${SRC_ROOT}/scan.cpp
+             ${SRC_ROOT}/numa_malloc.cpp   ${SRC_ROOT}/once.cpp)
+    endif()
+ENDMACRO(TMPI_GET_SOURCE_LIST)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,27 @@ set(ENSEMBLE_GPU_GEMC ON CACHE BOOL "Build GPU GEMC version")
 set(ENSEMBLE_GPU_GCMC ON CACHE BOOL "Build GPU GCMC version")
 set(ENSEMBLE_GPU_NPT ON CACHE BOOL "Build GPU NPT version")
 
+
+########################  MPI   ##################################
+
+include(${PROJECT_SOURCE_DIR}/CMake/GOMCOptionUtilities.cmake)
+
+option(GOMC_MPI    "Build a parallel (message-passing) version of GOMC" OFF)
+option(GOMC_THREAD_MPI  "Build a thread-MPI-based multithreaded version of GOMC (not compatible with MPI)" ON)
+
+include(${PROJECT_SOURCE_DIR}/CMake/GOMCManageMPI.cmake)
+include(${PROJECT_SOURCE_DIR}/CMake/ThreadMPI.cmake)
+
+set(GOMC_COMMON_LIBRARIES "")
+GOMC_dependent_option(
+    GOMC_MPI_IN_PLACE
+    "Enable MPI_IN_PLACE for MPIs that have it defined"
+    ON
+    GOMC_MPI)
+mark_as_advanced(GOMC_MPI_IN_PLACE)
+
+########################  MPI   ##################################
+
 #enable config header
 configure_file(
 	"${PROJECT_SOURCE_DIR}/GOMC_Config.h.in"

--- a/GOMC_Config.h.in
+++ b/GOMC_Config.h.in
@@ -2,3 +2,16 @@
 
 #define GOMC_VERSION_MAJOR @GOMC_VERSION_MAJOR@
 #define GOMC_VERSION_MINOR @GOMC_VERSION_MINOR@
+
+/* Use MPI (with mpicc) for parallelization */
+#cmakedefine01 GOMC_LIB_MPI
+
+/* Use threads_mpi for parallelization */
+#cmakedefine01 GOMC_THREAD_MPI
+
+/* Make a parallel version of GOMC using message passing
+   (MPI or thread_mpi) */
+#define GOMC_MPI (GOMC_LIB_MPI || GOMC_THREAD_MPI)
+
+/* MPI_IN_PLACE exists for collective operations */
+#cmakedefine01 MPI_IN_PLACE_EXISTS

--- a/metamake.sh
+++ b/metamake.sh
@@ -54,5 +54,6 @@ ICC_PATH="$(which icc)"
 ICPC_PATH="$(which icpc)"
 export CC=${ICC_PATH}
 export CXX=${ICPC_PATH}
-cmake ..
+#cmake ..
+cmake .. -DGOMC_MPI=on
 make

--- a/metamake_MPI.sh
+++ b/metamake_MPI.sh
@@ -54,5 +54,6 @@ ICC_PATH="$(which icc)"
 ICPC_PATH="$(which icpc)"
 export CC=${ICC_PATH}
 export CXX=${ICPC_PATH}
-cmake .. 
+#cmake ..
+cmake .. -DGOMC_MPI=on
 make

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -43,6 +43,9 @@ void PrintGPUHardwareInfo();
 
 int main(int argc, char *argv[])
 {
+if(GOMC_LIB_MPI)
+  std::cout << "Recognized MPI!\n";
+
 #ifndef NDEBUG
   PrintDebugMode();
 #endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -12,7 +12,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #endif
 #include <iostream>
 #include <ctime>
-
+#include <mpi.h>
 //find and include appropriate files for getHostname
 #ifdef _WIN32
 #include <Winsock2.h>
@@ -43,9 +43,18 @@ void PrintGPUHardwareInfo();
 
 int main(int argc, char *argv[])
 {
-if(GOMC_LIB_MPI)
-  std::cout << "Recognized MPI!\n";
+if(GOMC_LIB_MPI){
+      // Initialize the MPI environment
+      MPI_Init(NULL, NULL);
 
+      // Get the number of processes
+      int world_size;
+      MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+      // Get the rank of the process
+      int world_rank;
+      MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+}
 #ifndef NDEBUG
   PrintDebugMode();
 #endif


### PR DESCRIPTION
Setup CMake to recognize an argument called -DGOMC_MPI=on which will locate and link MPI.  A new macro called GOMC_LIB_MPI exists which will allow for logic branches in Main which will setup and run a multi-sim.  This code also has underlying thread-mpi linking if -DGOMC_MPI=on isn't provided, but MPI and thread-MPI are mutually exclusive.  If -DGOMC_MPI=on is given, thread-MPI is turned off.  Thread-MPI will not be introduced into GOMC as of right now.  It will eventually be useful for single replica domain-decomposition.