### PR TITLE
Patch - Fix building with metamake.sh

### DIFF
--- a/src/ParallelTemperingPreprocessor.cpp
+++ b/src/ParallelTemperingPreprocessor.cpp
@@ -6,6 +6,8 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 ********************************************************************************/
 
 #include "ParallelTemperingPreprocessor.h"
+
+#if GOMC_LIB_MPI
 ParallelTemperingPreprocessor::ParallelTemperingPreprocessor( int argc, 
                                                               char *argv[]){
   // Initialize the MPI environment
@@ -340,3 +342,5 @@ bool ParallelTemperingPreprocessor::CheckString(string str1, string str2)
 MultiSim::MultiSim(ParallelTemperingPreprocessor & pt) : 
   worldSize(pt.worldSize), worldRank(pt.worldRank), pathToReplicaDirectory(pt.pathToReplicaDirectory)
 {}
+
+#endif

--- a/src/ParallelTemperingPreprocessor.h
+++ b/src/ParallelTemperingPreprocessor.h
@@ -14,8 +14,11 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include <sys/stat.h>
 #include <sstream>
 #include <cstdlib>
-#include <mpi.h>
 
+#include "GOMC_Config.h"    //For version number
+#if GOMC_LIB_MPI
+#include <mpi.h>
+#endif
 
 #ifdef WIN32
 #define OS_SEP '\\'
@@ -25,6 +28,8 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 
 class ParallelTemperingPreprocessor {
 public:
+
+#if GOMC_LIB_MPI
 
 explicit ParallelTemperingPreprocessor( int argc, 
                                         char *argv[]);
@@ -45,6 +50,9 @@ private:
   fstream inputFileReaderMPI;
   std::string pathToReplicaDirectory;
   int worldSize, worldRank;
+  
+#endif
+
 };
 
 class MultiSim {


### PR DESCRIPTION
The ParallelTemperingPreprocessor.h/cpp files need macros over the MPI calls to allow for metamake.sh to build