### PR TITLE
Create new directory for MPI binaries & Fix the bug segfaulting in ConfigSetup when no multsim object is created

### DIFF
--- a/metamakeMPI.sh
+++ b/metamakeMPI.sh
@@ -48,7 +48,7 @@ else
 	echo "==== cub library already exists. Skipping..."
 fi
 
-mkdir -p bin
+mkdir -p bin_MPI
 cd bin
 ICC_PATH="$(which icc)"
 ICPC_PATH="$(which icpc)"

--- a/metamakeMPI.sh
+++ b/metamakeMPI.sh
@@ -49,7 +49,7 @@ else
 fi
 
 mkdir -p bin_MPI
-cd bin
+cd bin_MPI
 ICC_PATH="$(which icc)"
 ICPC_PATH="$(which icpc)"
 export CC=${ICC_PATH}

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -866,10 +866,15 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
     }
 #endif
     else if(CheckString(line[0], "OutputName")) {
-      std::stringstream replicaDirectory;
-      replicaDirectory << multisim->pathToReplicaDirectory << line[1];
-      out.statistics.settings.uniqueStr.val = replicaDirectory.str();
-      printf("%-40s %-s \n", "Info: Output name", replicaDirectory.str().c_str());
+      if (multisim != NULL){
+        std::stringstream replicaDirectory;
+        replicaDirectory << multisim->pathToReplicaDirectory << line[1];
+        out.statistics.settings.uniqueStr.val = replicaDirectory.str();
+        printf("%-40s %-s \n", "Info: Output name", replicaDirectory.str().c_str());
+      } else {
+        out.statistics.settings.uniqueStr.val = line[1];
+        printf("%-40s %-s \n", "Info: Output name", line[1].c_str());
+      }
     } else if(CheckString(line[0], "CheckpointFreq")) {
       out.checkpoint.enable = checkBool(line[1]);
       if(line.size() == 3)


### PR DESCRIPTION
This prevents cryptic errors when user tries to build both mpi and nonmpi versions of gomc.