### PR TITLE
Development branch fix

### DIFF
--- a/src/GPU/CalculateEnergyCUDAKernel.cu
+++ b/src/GPU/CalculateEnergyCUDAKernel.cu
@@ -297,7 +297,7 @@ __global__ void BoxInterGPU(int *gpu_cellStartIndex,
                                               sc_sigma_6,
                                               sc_alpha,
                                               sc_power,
-                                              gpu_sigmaSq[box],
+                                              gpu_sigmaSq,
                                               gpu_count[0]);
         }
         gpu_LJEn[threadID] += CalcEnGPU(distSq, kA, kB,
@@ -327,7 +327,7 @@ __device__ double CalcCoulombGPU(double distSq,
                                  double sc_sigma_6,
                                  double sc_alpha,
                                  uint sc_power,
-                                 double gpu_sigmaSq,
+                                 double * gpu_sigmaSq,
                                  int gpu_count)
 {
   if((gpu_rCutCoulomb * gpu_rCutCoulomb) < distSq) {
@@ -338,25 +338,25 @@ __device__ double CalcCoulombGPU(double distSq,
   if(gpu_VDW_Kind == GPU_VDW_STD_KIND) {
     return CalcCoulombParticleGPU(distSq, qi_qj_fact, gpu_ewald, gpu_alpha,
                                   gpu_lambdaCoulomb, sc_coul, sc_sigma_6,
-                                  sc_alpha, sc_power, gpu_sigmaSq);
+                                  sc_alpha, sc_power, gpu_sigmaSq[index]);
   } else if(gpu_VDW_Kind == GPU_VDW_SHIFT_KIND) {
     return CalcCoulombShiftGPU(distSq, qi_qj_fact, gpu_ewald, gpu_alpha,
                                gpu_rCutCoulomb, gpu_lambdaCoulomb, sc_coul,
-                               sc_sigma_6, sc_alpha, sc_power, gpu_sigmaSq);
+                               sc_sigma_6, sc_alpha, sc_power, gpu_sigmaSq[index]);
   } else if(gpu_VDW_Kind == GPU_VDW_EXP6_KIND) {
     return CalcCoulombExp6GPU(distSq, qi_qj_fact, gpu_ewald, gpu_alpha,
                               gpu_lambdaCoulomb, sc_coul, sc_sigma_6, sc_alpha,
-                              sc_power, gpu_sigmaSq);
+                              sc_power, gpu_sigmaSq[index]);
   } else if(gpu_VDW_Kind == GPU_VDW_SWITCH_KIND && gpu_isMartini) {
     return CalcCoulombSwitchMartiniGPU(distSq, qi_qj_fact, gpu_ewald, gpu_alpha,
                                        gpu_rCutCoulomb, gpu_diElectric_1,
                                        gpu_lambdaCoulomb, sc_coul, sc_sigma_6,
-                                       sc_alpha, sc_power, gpu_sigmaSq);
+                                       sc_alpha, sc_power, gpu_sigmaSq[index]);
   } else
     return CalcCoulombSwitchGPU(distSq, qi_qj_fact, gpu_alpha, gpu_ewald,
                                 gpu_rCutCoulomb, gpu_lambdaCoulomb,
                                 sc_coul, sc_sigma_6, sc_alpha, sc_power,
-                                gpu_sigmaSq);
+                                gpu_sigmaSq[index]);
 }
 
 __device__ double CalcEnGPU(double distSq, int kind1, int kind2,

--- a/src/GPU/CalculateEnergyCUDAKernel.cuh
+++ b/src/GPU/CalculateEnergyCUDAKernel.cuh
@@ -90,7 +90,7 @@ __device__ double CalcCoulombGPU(double distSq, int kind1, int kind2,
                                  int gpu_isMartini, double gpu_diElectric_1,
                                  double gpu_lambdaCoulomb, bool sc_coul,
                                  double sc_sigma_6, double sc_alpha,
-                                 uint sc_power, double gpu_sigmaSq,
+                                 uint sc_power, double * gpu_sigmaSq,
                                  int gpu_count);
 __device__ double CalcCoulombVirGPU(double distSq, double qi_qj,
                                     double gpu_rCutCoulomb, double gpu_alpha,

--- a/src/GPU/CalculateEwaldCUDAKernel.cu
+++ b/src/GPU/CalculateEwaldCUDAKernel.cu
@@ -86,7 +86,7 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
       imageSize);
   checkLastErrorCUDA(__FILE__, __LINE__);
 
-#ifndef NDEBUG
+//#ifndef NDEBUG
   // In the future maybe we could remove this for Nondebug?
   cudaMemcpy(sumRnew, vars->gpu_sumRnew[box],
              imageSize * sizeof(double),
@@ -94,7 +94,7 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
   cudaMemcpy(sumInew, vars->gpu_sumInew[box],
              imageSize * sizeof(double),
              cudaMemcpyDeviceToHost);
-#endif
+//#endif
 
   // ReduceSum
   void *d_temp_storage = NULL;
@@ -170,12 +170,12 @@ void CallMolReciprocalGPU(VariablesCUDA *vars,
                                       gpu_energyRecipNew,
                                       imageSize);
   checkLastErrorCUDA(__FILE__, __LINE__);
-#ifndef NDEBUG
+//#ifndef NDEBUG
   cudaMemcpy(sumRnew, vars->gpu_sumRnew[box], imageSize * sizeof(double),
              cudaMemcpyDeviceToHost);
   cudaMemcpy(sumInew, vars->gpu_sumInew[box], imageSize * sizeof(double),
              cudaMemcpyDeviceToHost);
-#endif
+//#endif
 
   // ReduceSum
   void *d_temp_storage = NULL;
@@ -245,13 +245,13 @@ void CallSwapReciprocalGPU(VariablesCUDA *vars,
                                        gpu_energyRecipNew,
                                        imageSize);
   checkLastErrorCUDA(__FILE__, __LINE__);
-#ifndef NDEBUG
+//#ifndef NDEBUG
   // In the future maybe we could remove this for Nondebug?
   cudaMemcpy(sumRnew, vars->gpu_sumRnew[box], imageSize * sizeof(double),
              cudaMemcpyDeviceToHost);
   cudaMemcpy(sumInew, vars->gpu_sumInew[box], imageSize * sizeof(double),
              cudaMemcpyDeviceToHost);
-#endif
+//#endif
 
   // ReduceSum
   void *d_temp_storage = NULL;

--- a/src/GPU/CalculateForceCUDAKernel.cu
+++ b/src/GPU/CalculateForceCUDAKernel.cu
@@ -881,7 +881,7 @@ __global__ void BoxForceGPU(int *gpu_cellStartIndex,
                                               gpu_diElectric_1[0],
                                               lambdaCoulomb, sc_coul, sc_sigma_6,
                                               sc_alpha, sc_power,
-                                              gpu_sigmaSq[box],
+                                              gpu_sigmaSq,
                                               gpu_count[0]);
         }
         gpu_LJEn[threadID] += CalcEnGPU(distSq, kA, kB, gpu_sigmaSq, gpu_n,

--- a/src/GPU/CalculateForceCUDAKernel.cu
+++ b/src/GPU/CalculateForceCUDAKernel.cu
@@ -881,7 +881,7 @@ __global__ void BoxForceGPU(int *gpu_cellStartIndex,
                                               gpu_diElectric_1[0],
                                               lambdaCoulomb, sc_coul, sc_sigma_6,
                                               sc_alpha, sc_power,
-                                              gpu_sigmaSq[threadID],
+                                              gpu_sigmaSq[box],
                                               gpu_count[0]);
         }
         gpu_LJEn[threadID] += CalcEnGPU(distSq, kA, kB, gpu_sigmaSq, gpu_n,


### PR DESCRIPTION
2 Changes:  
1) Fix the index into Sigma_Sq array (Size 2);  threadID (old) -> box (new) In BoxForce
2) Commented out the 3 NDEBUG's in Ewald CUDA kernel for memcpy'ing sumRnew and sumInew.  There was a comment speculating on the possibility that these calls could be removed for release mode, but apparently they are necessary.  Since there is 3 of them, and I know MP works when all three are included (1 1 1), and doesn't work when none of them are included (0 0 0), then 6 different combinations are possible (if you make a truth table).  Perhaps someone with better knowledge of this code knows why they would or wouldn't be neccessary.  This would save me the trouble of evaluation each of these 6 extra possibilities.

![image](https://user-images.githubusercontent.com/39970712/89231818-187e9580-d5b4-11ea-921c-d93b0764adf0.png)

![image](https://user-images.githubusercontent.com/39970712/89231757-f4bb4f80-d5b3-11ea-91e7-d7efc26bf409.png)

[input.zip](https://github.com/GOMC-WSU/GOMC/files/5018991/input.zip)
