### PR TITLE
Histogram all ensembles

### DIFF
--- a/CMake/FileLists.cmake
+++ b/CMake/FileLists.cmake
@@ -23,6 +23,7 @@ set(sources
    src/Geometry.cpp
    src/HistOutput.cpp
    src/InputFileReader.cpp
+   src/KernelDensityEstimator.cpp
    src/Main.cpp
    src/MoleculeKind.cpp
    src/MoleculeLookup.cpp
@@ -101,6 +102,7 @@ set(headers
    src/HistOutput.h
    src/InputAbstracts.h
    src/InputFileReader.h
+   src/KernelDensityEstimator.h
    src/MersenneTwister.h
    src/MoleculeKind.h
    src/MoleculeLookup.h

--- a/metamake.sh
+++ b/metamake.sh
@@ -50,9 +50,9 @@ fi
 
 mkdir -p bin
 cd bin
-ICC_PATH="$(which icc)"
-ICPC_PATH="$(which icpc)"
-export CC=${ICC_PATH}
-export CXX=${ICPC_PATH}
+#ICC_PATH="$(which icc)"
+#ICPC_PATH="$(which icpc)"
+#export CC=${ICC_PATH}
+#export CXX=${ICPC_PATH}
 cmake ..
-make
+make -j8 NVT

--- a/src/CPUSide.cpp
+++ b/src/CPUSide.cpp
@@ -10,10 +10,8 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 
 CPUSide::CPUSide(System & sys, StaticVals & statV) :
   varRef(sys, statV), pdb(sys, statV), console(varRef), block(varRef),
-  hist(varRef), checkpoint(sys, statV)
-#if ENSEMBLE == GCMC
-  , sample_N_E(varRef)
-#endif
+  hist(varRef), checkpoint(sys, statV), sample_N_E(varRef)
+#
 #if ENSEMBLE == NVT || ENSEMBLE == NPT
   , freeEnergy(varRef, sys)
 #endif
@@ -33,11 +31,10 @@ void CPUSide::Init(PDBSetup const& pdbSet, config_setup::Output const& out,
     outObj.push_back(&block);
   if (out.checkpoint.enable)
     outObj.push_back(&checkpoint);
-
-#if ENSEMBLE == GCMC
-  outObj.push_back(&hist);
-  outObj.push_back(&sample_N_E);
-#endif
+  if (out.statistics.settings.hist.enable){
+    outObj.push_back(&hist);
+    outObj.push_back(&sample_N_E);
+  }
 #if ENSEMBLE == NVT || ENSEMBLE == NPT
   outObj.push_back(&freeEnergy);
 #endif

--- a/src/CPUSide.cpp
+++ b/src/CPUSide.cpp
@@ -34,6 +34,7 @@ void CPUSide::Init(PDBSetup const& pdbSet, config_setup::Output const& out,
   if (out.statistics.settings.hist.enable){
     outObj.push_back(&hist);
     outObj.push_back(&sample_N_E);
+    outObj.push_back(&kde);
   }
 #if ENSEMBLE == NVT || ENSEMBLE == NPT
   outObj.push_back(&freeEnergy);

--- a/src/CPUSide.cpp
+++ b/src/CPUSide.cpp
@@ -10,7 +10,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 
 CPUSide::CPUSide(System & sys, StaticVals & statV) :
   varRef(sys, statV), pdb(sys, statV), console(varRef), block(varRef),
-  hist(varRef), checkpoint(sys, statV), sample_N_E(varRef)
+  hist(varRef), checkpoint(sys, statV), sample_N_E(varRef), kde(sample_N_E)
 #
 #if ENSEMBLE == NVT || ENSEMBLE == NPT
   , freeEnergy(varRef, sys)

--- a/src/CPUSide.h
+++ b/src/CPUSide.h
@@ -18,6 +18,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "CheckpointOutput.h"
 #include "EnPartCntSampleOutput.h"
 #include "FreeEnergyOutput.h"
+#include "KernelDensityEstimator.h"
 
 #include <vector>
 
@@ -45,6 +46,7 @@ private:
   FreeEnergyOutput freeEnergy;
 #endif
   OutputVars varRef;
+  KernelDensityEstimator kde;
 };
 
 #endif /*CPU_SIDE_H*/

--- a/src/CPUSide.h
+++ b/src/CPUSide.h
@@ -40,9 +40,7 @@ private:
   BlockAverages block;
   Histogram hist;
   CheckpointOutput checkpoint;
-#if ENSEMBLE == GCMC
   EnPartCntSample sample_N_E;
-#endif
 #if ENSEMBLE == NVT || ENSEMBLE == NPT
   FreeEnergyOutput freeEnergy;
 #endif

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -100,6 +100,7 @@ ConfigSetup::ConfigSetup(void)
   out.statistics.settings.block.enable = true;
 #if ENSEMBLE == GCMC
   sys.chemPot.isFugacity = false;
+#endif
   out.statistics.settings.hist.enable = false;
   out.statistics.settings.hist.frequency = ULONG_MAX;
   out.state.files.hist.histName = "";
@@ -107,7 +108,6 @@ ConfigSetup::ConfigSetup(void)
   out.state.files.hist.number = "";
   out.state.files.hist.sampleName = "";
   out.state.files.hist.stepsPerHistSample = UINT_MAX;
-#endif
   out.checkpoint.enable = false;
   out.checkpoint.frequency = ULONG_MAX;
   out.statistics.settings.uniqueStr.val = "";
@@ -977,7 +977,6 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
       } else
         printf("%-40s %-s \n", "Info: Average output", "Inactive");
     }
-#if ENSEMBLE == GCMC
     else if(CheckString(line[0], "HistogramFreq")) {
       out.statistics.settings.hist.enable = checkBool(line[1]);
       if(line.size() == 3)
@@ -1009,7 +1008,6 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
       printf("%-40s %-d \n", "Info: Histogram sample frequency",
              out.state.files.hist.stepsPerHistSample);
     }
-#endif
     else if(CheckString(line[0], "OutEnergy")) {
       out.statistics.vars.energy.block = checkBool(line[1]);
       out.statistics.vars.energy.fluct = checkBool(line[2]);
@@ -1841,7 +1839,6 @@ void ConfigSetup::verifyInputs(void)
     std::cout << "Error: Average output frequency is not specified!\n";
     exit(EXIT_FAILURE);
   }
-#if ENSEMBLE == GCMC
   if(out.statistics.settings.hist.enable &&
       out.statistics.settings.hist.frequency == ULONG_MAX) {
     std::cout << "Error: Histogram output frequency is not specified!\n";
@@ -1867,7 +1864,6 @@ void ConfigSetup::verifyInputs(void)
     std::cout << "Error: Histogram output sample frequency is not specified!\n";
     exit(EXIT_FAILURE);
   }
-#endif
   if(!out.statistics.settings.block.enable && out.statistics.vars.energy.block) {
     printf("Note: Average output Inactivated. Energy average output will be ignored.\n");
     out.statistics.vars.energy.block = false;

--- a/src/EnPartCntSampleOutput.cpp
+++ b/src/EnPartCntSampleOutput.cpp
@@ -118,6 +118,11 @@ void EnPartCntSample::DoOutput(const ulong step)
                   << "(energy and part. num samples file)" << std::endl;
     }
   }
+  // This is the only change to make in EnPartCntSample to allow KDE to tag along
+  // Since KDE Output needs a copy of this variable, we make a copy that has one purpose: 
+  // to be read by KDE.  Since these two methods are syncronous in their calls to DoOutput,
+  // with EnPart going first, KDE always has the correct value.
+  kdeSamplesCollectedInFrame = samplesCollectedInFrame;
   samplesCollectedInFrame = 0;
 }
 

--- a/src/EnPartCntSampleOutput.cpp
+++ b/src/EnPartCntSampleOutput.cpp
@@ -32,7 +32,7 @@ void EnPartCntSample::Init(pdb_setup::Atoms const& atoms,
   InitVals(output.statistics.settings.hist);
   if (enableOut) {
     stepsPerSample = output.state.files.hist.stepsPerHistSample;
-    uint samplesPerFrame =
+    samplesPerFrame =
       output.statistics.settings.hist.frequency / stepsPerSample + 1;
     samplesCollectedInFrame = 0;
     for (uint b = 0; b < BOXES_WITH_U_NB; ++b) {

--- a/src/EnPartCntSampleOutput.cpp
+++ b/src/EnPartCntSampleOutput.cpp
@@ -13,8 +13,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 
 #include <limits> // for std::numeric_limit
 
-#if ENSEMBLE == GCMC
-
 EnPartCntSample::~EnPartCntSample()
 {
   for (uint b = 0; b < BOXES_WITH_U_NB; ++b) {
@@ -142,5 +140,3 @@ std::string EnPartCntSample::GetFName(std::string const& sampleName,
   fName += ".dat";
   return fName;
 }
-
-#endif /*ENSEMBLE==GCMC*/

--- a/src/EnPartCntSampleOutput.h
+++ b/src/EnPartCntSampleOutput.h
@@ -58,12 +58,14 @@ private:
                        std::string const& histNum,
                        std::string const& histLetter,
                        const uint b);
-
+  
+  uint samplesPerFrame; 
   //samplesE --> per box; samplesN --> per kind, per box
   double * samplesE [BOXES_WITH_U_NB];
   uint ** samplesN [BOXES_WITH_U_NB], stepsPerSample, samplesCollectedInFrame;
   std::ofstream outF[BOXES_WITH_U_NB];
   std::string name [BOXES_WITH_U_NB];
+  friend class KernelDensityEstimator;
 };
 
 #endif /*EN_PART_CNT_SAMPLE_OUTPUT_H*/

--- a/src/EnPartCntSampleOutput.h
+++ b/src/EnPartCntSampleOutput.h
@@ -59,7 +59,7 @@ private:
                        std::string const& histLetter,
                        const uint b);
   
-  uint samplesPerFrame; 
+  uint samplesPerFrame, kdeSamplesCollectedInFrame; 
   //samplesE --> per box; samplesN --> per kind, per box
   double * samplesE [BOXES_WITH_U_NB];
   uint ** samplesN [BOXES_WITH_U_NB], stepsPerSample, samplesCollectedInFrame;

--- a/src/EnPartCntSampleOutput.h
+++ b/src/EnPartCntSampleOutput.h
@@ -19,8 +19,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "PDBSetup.h" //For atoms class.
 #include "EnergyTypes.h"
 
-#if ENSEMBLE == GCMC
-
 namespace config_setup
 {
 class Output;
@@ -67,7 +65,5 @@ private:
   std::ofstream outF[BOXES_WITH_U_NB];
   std::string name [BOXES_WITH_U_NB];
 };
-
-#endif /*ENSEMBLE==GCMC*/
 
 #endif /*EN_PART_CNT_SAMPLE_OUTPUT_H*/

--- a/src/HistOutput.cpp
+++ b/src/HistOutput.cpp
@@ -63,8 +63,8 @@ void Histogram::Init(pdb_setup::Atoms const& atoms,
     //Allocate and initialize to zero bin for maximum # of particles
     for (uint b = 0; b < BOXES_WITH_U_NB; ++b) {
       for (uint k = 0; k < var->numKinds; ++k) {
-        molCount[b][k] = new uint[total[k]];
-        for (uint n = 0; n < total[k]; ++n) {
+        molCount[b][k] = new uint[total[k]+1];
+        for (uint n = 0; n < total[k]+1; ++n) {
           molCount[b][k][n] = 0;
         }
       }
@@ -123,10 +123,10 @@ void Histogram::DoOutput(const ulong step)
 }
 void Histogram::PrintKindHist(const uint b, const uint k)
 {
-  for (uint n = 0; n < total[k]; ++n) {
-    if ( molCount[b][k][n] != 0 )
-      outF[b][k] << n << " " << molCount[b][k][n] << std::endl;;
-  }
+    for (uint n = 0; n < total[k]+1; ++n) {
+      if ( molCount[b][k][n] != 0 )
+        outF[b][k] << n << " " << molCount[b][k][n] << std::endl;
+    }
 }
 
 std::string Histogram::GetFName(std::string const& histName,

--- a/src/KernelDensityEstimator.cpp
+++ b/src/KernelDensityEstimator.cpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+GPU OPTIMIZED MONTE CARLO (GOMC) 2.60
+Copyright (C) 2018  GOMC Group
+A copy of the GNU General Public License can be found in the COPYRIGHT.txt
+along with this program, also can be found at <http://www.gnu.org/licenses/>.
+********************************************************************************/
+#include "KernelDensityEstimator.h"
+#include <sstream>
+
+KernelDensityEstimator::KernelDensityEstimator(EnPartCntSample & enPCS) : sampler(enPCS)
+{
+  for (uint b = 0; b < BOXES_WITH_U_NB; b++) {
+    outF[b] = NULL;
+    name[b] = NULL;
+  }
+
+  for (uint b = 0; b < BOXES_WITH_U_NB; ++b) {
+    energiesPerBox[b].resize(sampler.samplesPerFrame);
+    probabilitiesPerBox[b].resize(sampler.samplesPerFrame);
+  }
+}
+
+KernelDensityEstimator::~KernelDensityEstimator()
+{
+  for (uint b = 0; b < BOXES_WITH_U_NB; ++b) {
+    if (outF[b]->is_open()) outF[b]->close();
+  }
+}
+
+void KernelDensityEstimator::GeneratePDF(){
+
+  for (uint b = 0; b < BOXES_WITH_U_NB; ++b) {
+    std::copy(sampler.samplesE[b], sampler.samplesE[b] + sampler.samplesPerFrame, energiesPerBox[b].begin());
+    std::sort(energiesPerBox[b].begin(), energiesPerBox[b].end());
+  }
+
+  switch(k_h){
+    case BOXCAR:
+      int i, b, myBinCount, distance;
+      #if defined _OPENMP && _OPENMP >= 201511 // check if OpenMP version is 4.5
+      #pragma omp parallel for default(none) private(b, i, myBinCount, distance) shared(energiesPerBox, probabilitiesPerBox) collapse(2)
+      #endif
+      for(b = 0; b < BOXES_WITH_U_NB; b++){
+        for (i = 0; i < sampler.samplesPerFrame; i++){
+          myBinCount = 1;
+          distance = 1;
+          while (i < sampler.samplesPerFrame && i + distance < sampler.samplesPerFrame &&  abs(energiesPerBox[b][i] - energiesPerBox[b][i + distance]) < h ){
+            myBinCount++;
+            distance++;
+          }
+          distance = 1;
+          while (i > 0 && i - distance >= 0 &&  abs(energiesPerBox[b][i] - energiesPerBox[b][i - distance]) < h ){
+            myBinCount++;
+            distance++;
+          }
+          probabilitiesPerBox[b][i] =  (double)myBinCount / (double)sampler.samplesPerFrame;
+        }
+      }
+
+      break;
+
+    case GAUSSIAN:
+
+      break;
+
+    default:
+
+      break;
+  }
+}

--- a/src/KernelDensityEstimator.cpp
+++ b/src/KernelDensityEstimator.cpp
@@ -10,6 +10,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 KernelDensityEstimator::KernelDensityEstimator(EnPartCntSample & enPCS) : sampler(enPCS)
 {
   kdeCounter = 0;
+  h = 1.0;
 }
 
 KernelDensityEstimator::~KernelDensityEstimator()
@@ -124,6 +125,7 @@ void KernelDensityEstimator::DoOutput(const ulong step)
 void KernelDensityEstimator::PrintKDE(const uint b)
 {
     for (uint n = 0; n < sampler.kdeSamplesCollectedInFrame; ++n) {
+        outF[b].precision(dbl::max_digits10);
         outF[b] << kdeCounter << " " << energiesPerBox[b][n] << " " << probabilitiesPerBox[b][n] << std::endl;
     }
     kdeCounter++;

--- a/src/KernelDensityEstimator.h
+++ b/src/KernelDensityEstimator.h
@@ -31,7 +31,7 @@ class KernelDensityEstimator : public OutputableBase {
   void PrintKDE(const uint b);  
 
   
-
+  uint kdeCounter;
   double h;
   KernelType k_h;
   uint stepsPerSample;
@@ -40,6 +40,7 @@ class KernelDensityEstimator : public OutputableBase {
   EnPartCntSample & sampler;
   std::vector< std::vector<double> > energiesPerBox;
   std::vector< std::vector<double> > probabilitiesPerBox;
+  friend class EnPartCntSample;
 };
 
 #endif /*KERNELDENSITYESTIMATOR_H*/

--- a/src/KernelDensityEstimator.h
+++ b/src/KernelDensityEstimator.h
@@ -6,7 +6,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 ********************************************************************************/
 #ifndef KERNELDENSITYESTIMATOR_H
 #define KERNELDENSITYESTIMATOR_H
-
+  
 #include <string>
 #include <fstream>
 #include "EnPartCntSampleOutput.h"
@@ -14,17 +14,29 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 enum KernelType{ BOXCAR, GAUSSIAN };
 
 
-class KernelDensityEstimator : OutputableBase {
+class KernelDensityEstimator : public OutputableBase {
   public:
   KernelDensityEstimator(EnPartCntSample & sampler);
   void GeneratePDF();
   ~KernelDensityEstimator();
 
+  //We use the EnPartCntSample as our sampler, so do nothing.
+  virtual void Sample(const ulong step) {}
+
+  virtual void Init(pdb_setup::Atoms const& atoms,
+                    config_setup::Output const& output);
+
+  virtual void DoOutput(const ulong step);
+
+  void PrintKDE(const uint b);  
+
+  
+
   double h;
   KernelType k_h;
   uint stepsPerSample;
-  std::ofstream * outF [BOXES_WITH_U_NB];
-  std::string * name [BOXES_WITH_U_NB];
+  std::ofstream outF [BOXES_WITH_U_NB];
+  std::string name [BOXES_WITH_U_NB];
   EnPartCntSample & sampler;
   std::vector< std::vector<double> > energiesPerBox;
   std::vector< std::vector<double> > probabilitiesPerBox;

--- a/src/KernelDensityEstimator.h
+++ b/src/KernelDensityEstimator.h
@@ -14,13 +14,13 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 enum KernelType{ BOXCAR, GAUSSIAN };
 
 
-class KernelDensityEstimator {
+class KernelDensityEstimator : OutputableBase {
   public:
   KernelDensityEstimator(EnPartCntSample & sampler);
   void GeneratePDF();
   ~KernelDensityEstimator();
 
-  int h;
+  double h;
   KernelType k_h;
   uint stepsPerSample;
   std::ofstream * outF [BOXES_WITH_U_NB];

--- a/src/KernelDensityEstimator.h
+++ b/src/KernelDensityEstimator.h
@@ -1,0 +1,33 @@
+/*******************************************************************************
+GPU OPTIMIZED MONTE CARLO (GOMC) 2.60
+Copyright (C) 2018  GOMC Group
+A copy of the GNU General Public License can be found in the COPYRIGHT.txt
+along with this program, also can be found at <http://www.gnu.org/licenses/>.
+********************************************************************************/
+#ifndef KERNELDENSITYESTIMATOR_H
+#define KERNELDENSITYESTIMATOR_H
+
+#include <string>
+#include <fstream>
+#include "EnPartCntSampleOutput.h"
+
+enum KernelType{ BOXCAR, GAUSSIAN };
+
+
+class KernelDensityEstimator {
+  public:
+  KernelDensityEstimator(EnPartCntSample & sampler);
+  void GeneratePDF();
+  ~KernelDensityEstimator();
+
+  int h;
+  KernelType k_h;
+  uint stepsPerSample;
+  std::ofstream * outF [BOXES_WITH_U_NB];
+  std::string * name [BOXES_WITH_U_NB];
+  EnPartCntSample & sampler;
+  std::vector< std::vector<double> > energiesPerBox;
+  std::vector< std::vector<double> > probabilitiesPerBox;
+};
+
+#endif /*KERNELDENSITYESTIMATOR_H*/

--- a/src/KernelDensityEstimator.h
+++ b/src/KernelDensityEstimator.h
@@ -11,6 +11,10 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include <fstream>
 #include "EnPartCntSampleOutput.h"
 
+#include <limits>
+
+typedef std::numeric_limits< double > dbl;
+
 enum KernelType{ BOXCAR, GAUSSIAN };
 
 


### PR DESCRIPTION
This commit  removes the compiler pragmas that prevent EnCntPartSample and Histogram from being usable in other ensembles.  To create a histogram in a non-GCMC ensemble, simply provide the same parameters to the config file you would in a GCMC run.

This commit also implements a Kernel Density Estimator which piggybacks off the EnCntPartSample class.  As of right now, only the Box Car kernel is implemented which creates N bins, where N is the number of samples, and the width of the bin is hard coded to 1.0 K.  Since the space KDE works in is continuous as opposed to discrete, the previously generated kde cannot be used reused in a new kde.  Instead of overwriting the values in the kde file, KDE's are given an index.

The format for the KDE file is as follows:
kde_index (0 to number of kdes generated throughout a run)        energy_of_bin (x-axis)        probability (y-axis)