### PR TITLE
Fix to issue #226

### DIFF
--- a/src/GPU/CalculateEwaldCUDAKernel.cu
+++ b/src/GPU/CalculateEwaldCUDAKernel.cu
@@ -534,6 +534,7 @@ __global__ void BoxForceReciprocalGPU(
   double z = gpu_z[particleID];
   double lambdaCoef = DeviceGetLambdaCoulomb(moleculeID, kindID, box, gpu_isFraction, gpu_molIndex, gpu_kindIndex, gpu_lambdaCoulomb);
 
+  __syncthreads();
   // loop over images
   for(int vectorIndex = 0; vectorIndex < numberOfVectors; vectorIndex ++) {
     double dot = x * shared_kvector[vectorIndex*3] + y *


### PR DESCRIPTION
@LSchwiebert: It seems like the energy difference in second step was not caused by `BoxReciprocalSetup` and `BoxReciprocal`. I printed all the coordinates before getting to those functions on the second step and some coordinates were off slightly. At this point it was obvious that the first step was setting incorrect forces for atoms and molecules (which was causing different trial positions for second step). After printing all the forces (after `BoxForceReciprocal` function), it seemed like only the atoms with indexes of multiple of `64` were getting incorrect results. It was different each time as well. Which meant the first iteration of the following loop was giving incorrect result.

https://github.com/GOMC-WSU/GOMC/blob/cc553ea42397259fc43b01e6459887f1dbdb2095/src/GPU/CalculateEwaldCUDAKernel.cu#L538

Putting `__syncthreads` before this loop ensures that data is loaded to shared memory before accessing them.