### PR TITLE
Error checking of PSF file for headers appropriate to forcefield type.

### DIFF
--- a/src/FFSetup.h
+++ b/src/FFSetup.h
@@ -16,6 +16,8 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "Reader.h" //For Reader object
 #include "FFConst.h" //for forcefield constants
 #include "BasicTypes.h" //for uint
+#include "InputFileReader.h"
+
 
 namespace ff_setup
 {
@@ -303,6 +305,8 @@ private:
   static const std::string paramFileAlias[];
   static const uint CHARMM_ALIAS_IDX;
   static const uint EXOTIC_ALIAS_IDX;
+  bool hasEnding (std::string const &fullString, std::string const &ending);
+
 };
 
 


### PR DESCRIPTION
If the PSF file has headers that end in _MIE, and **ParaTypeCharmm	 true**, we break and print : 

Error: CHARMM-Style parameter is set but EXOTIC-Style parameter header NONBONDED_MIE was found.
       Either set EXOTIC-Style in config file or change the keyword
       NONBONDED_MIE to NONBONDED in the parameter files.

or 

Error: CHARMM-Style parameter is set but EXOTIC-Style parameter header NBFIX_MIE was found.
       Either set EXOTIC-Style in config file or change the keyword
       NBFIX_MIE to NBFIX in the parameter files.

If the PSF file has headers "NONBONDED" or "NBFIX" and **ParaTypeExotic	 true** or  **ParaTypeMie	 true**, we break and print:

Error: EXOTIC-Style parameter is set but CHARMM-Style parameter header NONBONDED was found.
       Either set CHARMM-Style in config file or change the keyword
       NONBONDED to NONBONDED_MIE in the parameter files.

or 

Error: EXOTIC-Style parameter is set but CHARMM-Style parameter header NBFIX was found.
       Either set CHARMM-Style in config file or change the keyword
       NBFIX to NBFIX_MIE in the parameter files.
