### PR TITLE
Read in restart binary coordinate and extended system file

### DIFF
--- a/CMake/FileLists.cmake
+++ b/CMake/FileLists.cmake
@@ -15,6 +15,7 @@ set(sources
    src/DCDlib.cpp
    src/DCDOutput.cpp
    src/EnPartCntSampleOutput.cpp
+   src/ExtendedSystem.cpp
    src/Ewald.cpp
    src/EwaldCached.cpp
    src/FFConst.cpp
@@ -87,6 +88,7 @@ set(headers
    src/EnergyTypes.h
    src/EnPartCntSampleOutput.h
    src/EnsemblePreprocessor.h
+   src/ExtendedSystem.h
    src/Ewald.h
    src/EwaldCached.h  
    src/FFAngles.h

--- a/src/BoxDimensions.cpp
+++ b/src/BoxDimensions.cpp
@@ -19,7 +19,7 @@ void BoxDimensions::Init(config_setup::RestartSettings const& restart,
     rCut[b] = std::max(ff.rCut, ff.rCutCoulomb[b]);
     rCutSq[b] = rCut[b] * rCut[b];
     minVol[b] = 8.0 * rCutSq[b] * rCut[b] + 0.001;
-    if(restart.enable && cryst.hasVolume) {
+    if(restart.enable && cryst.hasVolume[b]) {
       axis = cryst.axis;
       double alpha = cos(cryst.cellAngle[b][0] * M_PI / 180.0);
       double beta  = cos(cryst.cellAngle[b][1] * M_PI / 180.0);
@@ -40,11 +40,13 @@ void BoxDimensions::Init(config_setup::RestartSettings const& restart,
       cellBasis[b].Scale(0, axis.Get(b).x);
       cellBasis[b].Scale(1, axis.Get(b).y);
       cellBasis[b].Scale(2, axis.Get(b).z);
+    } else if (restart.enable && cryst.hasCellBasis[b]) {
+      cryst.cellBasis[b].CopyRange(cellBasis[b], 0, 0, 3);
     } else if(confVolume.hasVolume) {
       confVolume.axis[b].CopyRange(cellBasis[b], 0, 0, 3);
     } else {
       fprintf(stderr,
-              "Error: Cell Basis not specified in PDB or in.conf files.\n");
+              "Error: Cell Basis not specified in XSC, PDB, or in.conf files.\n");
       exit(EXIT_FAILURE);
     }
 

--- a/src/BoxDimensionsNonOrth.cpp
+++ b/src/BoxDimensionsNonOrth.cpp
@@ -20,7 +20,7 @@ void BoxDimensionsNonOrth::Init(config_setup::RestartSettings const& restart,
     rCut[b] = std::max(ff.rCut, ff.rCutCoulomb[b]);
     rCutSq[b] = rCut[b] * rCut[b];
     minVol[b] = 8.0 * rCutSq[b] * rCut[b] + 0.001;
-    if(restart.enable && cryst.hasVolume) {
+    if(restart.enable && cryst.hasVolume[b]) {
       axis = cryst.axis;
       double alpha = cos(cryst.cellAngle[b][0] * M_PI / 180.0);
       double beta  = cos(cryst.cellAngle[b][1] * M_PI / 180.0);
@@ -41,11 +41,13 @@ void BoxDimensionsNonOrth::Init(config_setup::RestartSettings const& restart,
       cellBasis[b].Scale(0, axis.Get(b).x);
       cellBasis[b].Scale(1, axis.Get(b).y);
       cellBasis[b].Scale(2, axis.Get(b).z);
+    } else if (restart.enable && cryst.hasCellBasis[b]) {
+      cryst.cellBasis[b].CopyRange(cellBasis[b], 0, 0, 3);
     } else if(confVolume.hasVolume) {
       confVolume.axis[b].CopyRange(cellBasis[b], 0, 0, 3);
     } else {
       fprintf(stderr,
-              "Error: Cell Basis not specified in PDB or in.conf files.\n");
+              "Error: Cell Basis not specified in XSC, PDB, or in.conf files.\n");
       exit(EXIT_FAILURE);
     }
 

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -43,12 +43,20 @@ namespace config_setup
 //A filename
 struct FileName {
   std::string name;
+  bool defined;
+  FileName(void) {
+    defined = false; 
+  }
 };
 
 //Multiple filenames
 template <uint N>
 struct FileNames {
   std::string name[N];
+  bool defined[N];
+  FileNames(void) {
+    std::fill_n(defined, N, false);  
+  }
 };
 
 /////////////////////////////////////////////////////////////////////////
@@ -61,6 +69,8 @@ struct RestartSettings {
   ulong step;
   bool recalcTrajectory;
   bool restartFromCheckpoint;
+  bool restartFromBinaryFile;
+  bool restartFromXSCFile;
   bool operator()(void)
   {
     return enable;
@@ -95,7 +105,7 @@ struct FFKind {
 //Files for input.
 struct InFiles {
   FileName param;
-  FileNames<BOX_TOTAL> pdb, psf;
+  FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput;
   FileName seed;
 };
 

--- a/src/DCDOutput.cpp
+++ b/src/DCDOutput.cpp
@@ -54,6 +54,7 @@ void DCDOutput::Init(pdb_setup::Atoms const& atoms,
       printNotify = false;
 #endif
 
+  // Output dcd coordinates and xst file
   if (enableStateOut) {
     int numAtoms = coordCurrRef.Count();
     x = new float [3 * numAtoms];
@@ -78,6 +79,7 @@ void DCDOutput::Init(pdb_setup::Atoms const& atoms,
     }
   }
 
+  // Output restart binary coordinates and xsc file
   if (enableRestartOut) {
     for (uint b = 0; b < BOX_TOTAL; ++b) {
       std::string fileName = output.restart_dcd.files.dcd.name[b];
@@ -120,7 +122,7 @@ void DCDOutput::Write_Extention_System_data(Writer &outFile,
     outFile.file << step + 1;
   }
 
-  // because we normalized the cell basis, we need to do this
+  // because we normalized the cell basis, we need to reverse it
   XYZ a = boxDimRef.cellBasis[box].Get(0) * boxDimRef.GetAxis(box).x;
   XYZ b = boxDimRef.cellBasis[box].Get(1) * boxDimRef.GetAxis(box).y;
   XYZ c = boxDimRef.cellBasis[box].Get(2) * boxDimRef.GetAxis(box).z;
@@ -174,9 +176,10 @@ void DCDOutput::WriteDCDHeader(const int numAtoms, const int box)
 
 void DCDOutput::DoOutput(const ulong step)
 {
+  // Output dcd coordinates and xst file
   if(enableStateOut) {
     int numAtoms = coordCurrRef.Count();
-    // Determin which molecule is each box. assume we are in NVT
+    // Determin which molecule is in which box. Assume we are in NVT
     // or NPT, otherwise, SetMolBoxVec would adjust the value.
     std::vector<int> molInBox(molRef.count, 0);
     SetMolBoxVec(molInBox);
@@ -206,10 +209,11 @@ void DCDOutput::DoOutput(const ulong step)
     }
   }
 
-
+  // Output restart binary coordinates and xsc file
   if (((step + 1) % stepsRestartPerOut == 0) && enableRestartOut) {
     for (uint b = 0; b < BOX_TOTAL; ++b) {
       int numAtomInBox = NumAtomInBox(b);
+      // Copy the coordinate data for each box into AOS
       SetMolInBox(b);
       printf("Writing binary restart coordinate to file %s at step %d \n",
         outDCDRestartFile[b], step+1);

--- a/src/DCDOutput.h
+++ b/src/DCDOutput.h
@@ -70,13 +70,14 @@ public:
 
   virtual void DoOutput(const ulong step);
 private:
-
+  // Copy cell length and angles to unitcell[6]
   void Copy_lattice_to_unitcell(double *unitcell, int box);
+  // Unwrap and save coordinates of molecule in box, into *x, *y, *z
   void SetCoordinates(float *x, float *y, float *d,
       std::vector<int> &molInBox, const int box);
-  // unwrap and same coordinates of molecule in box
+  // Unwrap and save coordinates of molecule in box, into *restartCoor
   void SetMolInBox(const int box);
-  //Return a vector that defines the box id for each molecule
+  // Return a vector that defines the box id for each molecule
   void SetMolBoxVec(std::vector<int> & mBox);
   // returns the total number of atoms in box
   int NumAtomInBox(const int box);
@@ -99,16 +100,19 @@ private:
 
   char *outDCDStateFile[BOX_TOTAL];
   char *outDCDRestartFile[BOX_TOTAL];
+  char *outXSTFile[BOX_TOTAL];
+  char *outXSCFile[BOX_TOTAL];
   int stateFileFileid[BOX_TOTAL];
   bool enableRestartOut, enableStateOut;
   ulong stepsRestartPerOut, stepsStatePerOut;
+  // 
   float *x, *y, *z;
-  XYZ *restartCoor[BOX_TOTAL];
+  // AOS for restart binary format. NAMD internal data structure 
+  // is array of vector(XYZ)
+  XYZ *restartCoor[BOX_TOTAL]; 
   // for extension system files
   Writer xstFile[BOX_TOTAL];
   Writer xscFile[BOX_TOTAL];
-  char *outXSTFile[BOX_TOTAL];
-  char *outXSCFile[BOX_TOTAL];
 };
 
 #endif /*DCD_OUTPUT_H*/

--- a/src/DCDlib.cpp
+++ b/src/DCDlib.cpp
@@ -1269,6 +1269,7 @@ void read_binary_file(const char *fname, XYZ *data, int n)
     }
   }
 
+  std::cout << "Info: Finished reading from binary file " << fname << "\n" << std::endl;
 }
 
 

--- a/src/DCDlib.cpp
+++ b/src/DCDlib.cpp
@@ -319,7 +319,6 @@ int open_dcd_read(char *filename)
 /*								*/
 /****************************************************************/
 
-#if 0
 int read_dcdheader(int fd, int *N, int *NSET, int *ISTART, 
 		   int *NSAVC, double *DELTA, int *NAMNF, 
 		   int **FREEINDEXES)
@@ -742,7 +741,7 @@ int read_dcdstep(int fd, int N, float *X, float *Y, float *Z, int num_fixed,
 
 	return(0);
 }
-#endif
+
 
 #ifndef OUTPUT_SINGLE_FILE
 #error OUTPUT_SINGLE_FILE not defined!
@@ -1197,3 +1196,198 @@ void close_dcd_write(int fd)
   }
 }
 
+void read_binary_file(const char *fname, XYZ *data, int n)
+{
+  int32 filen;          //  Number of atoms read from file
+  FILE *fp;             //  File descriptor
+  int needToFlip = 0;
+
+  std::cout << "Info: Reading from binary file " << fname << "\n" << std::endl;
+
+  //  Open the file and die if the open fails
+  if ( (fp = Fopen(fname, "rb")) == NULL)
+  {
+    char errmsg[256];
+    sprintf(errmsg, "Unable to open binary file %s", fname);
+    NAMD_die(errmsg);
+  }
+
+  //  read the number of coordinates in this file
+  if (fread(&filen, sizeof(int32), 1, fp) != (size_t)1)
+  {
+    char errmsg[256];
+    sprintf(errmsg, "Error reading binary file %s", fname);
+    NAMD_die(errmsg);
+  }
+
+  //  read the number of coordinates in this file
+  //  check for palindromic number of atoms
+  char lenbuf[4];
+  memcpy(lenbuf, (const char *)&filen, 4);
+  char tmpc;
+  tmpc = lenbuf[0]; lenbuf[0] = lenbuf[3]; lenbuf[3] = tmpc;
+  tmpc = lenbuf[1]; lenbuf[1] = lenbuf[2]; lenbuf[2] = tmpc;
+  if ( ! memcmp((const char *)&filen, lenbuf, 4) ) {
+    std::cout << "Warning: Number of atoms in binary file " << fname <<
+		" is palindromic, assuming same endian.\n" << std::endl;
+  }
+
+  //  Die if this doesn't match the number in our system
+  if (filen != n)
+  {
+    needToFlip = 1;
+    memcpy((char *)&filen, lenbuf, 4);
+  }
+  if (filen != n)
+  {
+    char errmsg[256];
+    sprintf(errmsg, "Incorrect atom count in binary file %s", fname);
+    NAMD_die(errmsg);
+  }
+
+  if (fread(data, sizeof(XYZ), n, fp) != (size_t)n)
+  {
+    char errmsg[256];
+    sprintf(errmsg, "Error reading binary file %s", fname);
+    NAMD_die(errmsg);
+  }
+
+  Fclose(fp);
+
+  if (needToFlip) { 
+    std::cout << "Converting binary file " << fname << "\n" << std::endl;
+    int i;
+    char *cdata = (char *) data;
+    for ( i=0; i<3*n; ++i, cdata+=8 ) {
+      char tmp0, tmp1, tmp2, tmp3;
+      tmp0 = cdata[0]; tmp1 = cdata[1];
+      tmp2 = cdata[2]; tmp3 = cdata[3];
+      cdata[0] = cdata[7]; cdata[1] = cdata[6];
+      cdata[2] = cdata[5]; cdata[3] = cdata[4];
+      cdata[7] = tmp0; cdata[6] = tmp1;
+      cdata[5] = tmp2; cdata[4] = tmp3;
+    }
+  }
+
+}
+
+
+/***************************************************************************
+ Fopen(char *Filename, char *mode):  similar to fopen(filename,mode) except
+ it checks for compressed file names too.
+ For example:  Fopen("config");
+   This will first look for the filename "config" (and return "r" file handle
+   if it is found).
+   Then it will look for "config.Z" (and run "zcat config.Z", returning
+   a file handle to the uncompressed data if found).
+   Then it will look for "config.gz" (and run "gzip -d -c config.gz", returning
+   a file handle to the uncompressed data if found).
+ ***************************************************************************/
+FILE *Fopen	(const char *filename, const char *mode)
+{
+  struct stat buf;
+  // check if basic filename exists (and not a directory)
+
+#if defined(NOCOMPRESSED)
+  if (!stat(filename,&buf))
+    {
+      FILE *rval;
+      while ( ! (rval = fopen(filename,mode)) ) {
+        if ( errno != EINTR ) break;
+      }
+      return(rval);
+    }
+#else
+  if (!stat(filename,&buf))
+    {
+      if (!S_ISDIR(buf.st_mode)) {
+        FILE *rval;
+        while ( ! (rval = fopen(filename,mode)) ) {
+          if ( errno != EINTR ) break;
+        }
+        return(rval);
+      }
+    }
+  // check for a compressed file
+  /*
+  char *realfilename;
+  char *command;
+  FILE *fout;
+  command = (char *)malloc(strlen(filename)+25);
+  // check for .Z (unix compress)
+  sprintf(command,"zcat %s.Z",filename);
+  realfilename = command+5;
+  iout << "Command = " << command << "\n" << endi;
+  iout << "Filename.Z = " << realfilename << "\n" << endi;
+  if (!stat(realfilename,&buf))
+	{
+	if (!S_ISDIR(buf.st_mode))
+		{
+		fout = popen(command,mode);
+		// on HP-UX, the first character(s) out of pipe may be
+		// garbage!  (Argh!)
+		int C;
+		do
+		  {
+		  C = fgetc(fout);
+		  // iout << "C is " << C << "\n" << endi;
+		  if (isalnum(C) || isspace(C))
+			{
+			ungetc(C,fout);
+			C = -1;	// outta loop
+			}
+		  } while(C != -1);
+		free(command);
+		return(fout);
+		}
+	}
+  // check for .gz (gzip)
+  sprintf(command,"gzip -d -c %s.gz",filename);
+  realfilename = command+11;
+  iout << "Command = " << command << "\n" << endi;
+  iout << "Filename.gz = " << realfilename << "\n" << endi;
+  if (!stat(realfilename,&buf))
+	{
+	if (!S_ISDIR(buf.st_mode))
+		{
+		fout = popen(command,mode);
+		// on HP-UX, the first character(s) out of pipe may be
+		// garbage!  (Argh!)
+		int C;
+		do
+		  {
+		  C = fgetc(fout);
+		  // iout << "C is " << C << "\n" << endi;
+		  if (isalnum(C) || isspace(C))
+			{
+			ungetc(C,fout);
+			C = -1;	// outta loop
+			}
+		  } while(C != -1);
+		free(command);
+		return(fout);
+		}
+	}
+  free(command);
+  */
+#endif /* !defined(NOCOMPRESSED) */
+
+  return(NULL);
+} /* Fopen() */
+
+/***************************************************************************
+ Fclose(FILE *fout):  similar to fclose(fout) except it first checks if the
+ file handle fout is a named pipe.
+ ***************************************************************************/
+int	Fclose	(FILE *fout)
+{
+  int rc = -1;
+#if !defined(NOCOMPRESSED)
+  rc = pclose(fout);
+#endif
+  if (rc == -1)	// stream not associated with a popen()
+    {
+    rc = fclose(fout);
+    }
+  return rc;
+} /* Fclose() */

--- a/src/DCDlib.h
+++ b/src/DCDlib.h
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <iostream>
+#include "BasicTypes.h"
 #ifndef _NO_MALLOC_H
 #include <malloc.h>
 #endif
@@ -36,6 +37,8 @@
 #include <time.h>
 #ifdef WIN32
 #include <io.h>
+#define access(PATH,MODE) _access(PATH,00)
+#define NOCOMPRESSED
 #endif
 
 #ifndef __off_t_defined
@@ -96,7 +99,13 @@ int update_dcdstep_par_header(int fd);
 
 /* Write out a timesteps values partially in parallel for part [parL, parU] */
 int write_dcdstep_par_slave(int fd, int parL, int parU, int N, float *X, float *Y, float *Z);
-    
+
+/* Read binary coordinate file and store coordinates in XYZ array */
+void read_binary_file(const char *fname, XYZ *data, int n);
+
+FILE *Fopen(const char *filename, const char *mode);
+int  Fclose(FILE *fout);
+
 /* wrapper for seeking the dcd file */
 OFF_T NAMD_seek(int file, OFF_T offset, int whence);
 

--- a/src/ExtendedSystem.cpp
+++ b/src/ExtendedSystem.cpp
@@ -1,0 +1,167 @@
+/*******************************************************************************
+GPU OPTIMIZED MONTE CARLO (GOMC) 2.70
+Copyright (C) 2018  GOMC Group
+A copy of the GNU General Public License can be found in the COPYRIGHT.txt
+along with this program, also can be found at <http://www.gnu.org/licenses/>.
+********************************************************************************/
+#include <vector>
+#include "StrLib.h" //for string comparison wrapper
+#include "ExtendedSystem.h" //Corresponding header to this body
+#include "FixedWidthReader.h" //For fixed width reader
+#include "ConfigSetup.h" //For restart info
+#include "DCDlib.h" // for Error output
+#include <stdlib.h> //for exit
+#include <string> // for to_string
+
+ExtendedSystem::ExtendedSystem()
+{
+  firstStep = 0;
+  axis.Init(BOX_TOTAL);
+  for(int b = 0; b < BOX_TOTAL; b++) {
+    cellBasis[b] = XYZArray(3);
+    hasCellBasis[b] = false;
+    center[b].Reset();
+  }
+}
+
+void ExtendedSystem::Init(PDBSetup &pdb, config_setup::Input inputFiles)
+{
+  if(inputFiles.restart.restartFromXSCFile) {
+    for(int b = 0; b < BOX_TOTAL; b++) {
+      if(inputFiles.files.xscInput.defined[b]) {
+        std::string fName = inputFiles.files.xscInput.name[b];
+        ReadExtendedSystem(fName.c_str(), b);
+        UpdateCellBasis(pdb, b);
+      }
+    }
+  }
+}
+
+
+void ExtendedSystem::UpdateCellBasis(PDBSetup &pdb, const int box)
+{
+  if (hasCellBasis[box]) {
+    pdb.cryst.hasCellBasis[box] = true;
+    pdb.cryst.hasVolume[box] = false;
+    cellBasis[box].CopyRange(pdb.cryst.cellBasis[box], 0, 0, 3);
+    pdb.cryst.axis.Set(box, axis.Get(box));
+    //pdb.remarks.step[box] = firstStep;
+    for(int i = 0; i < 3; i++) {
+      pdb.cryst.cellAngle[box][i] = cellAngle[box][i];
+    }
+  }
+}
+
+void ExtendedSystem::ReadExtendedSystem(const char *filename, const int box)
+{
+  char msg[257];
+  sprintf(msg, "Info: Reading BOX %d extended system file %s \n", box+1, filename);
+  std::cout << msg << std::endl;
+     
+  std::ifstream xscFile(filename);
+  if ( ! xscFile ){
+    sprintf(msg, "Unable to open BOX %d extended system file %s!\n",
+            box+1, filename);
+    NAMD_die(msg);
+  }
+
+  char labels[1024];
+  do {
+    if ( ! xscFile ){
+      sprintf(msg, "Reading BOX %d extended system file %s! \n",
+              box+1, filename);
+      NAMD_die(msg);
+    }
+    xscFile.getline(labels,1023);
+  } while ( strncmp(labels,"#$LABELS ",9) );
+
+  int a_x, a_y, a_z, b_x, b_y, b_z, c_x, c_y, c_z;
+  a_x = a_y = a_z = b_x = b_y = b_z = c_x = c_y = c_z = -1;
+  int o_x, o_y, o_z;
+  o_x = o_y = o_z = -1;
+
+  int pos = 0;
+  char *l_i = labels + 8;
+  while ( *l_i ) {
+    if ( *l_i == ' ' ) { 
+      ++l_i; 
+      continue; 
+    }
+    char *l_i2;
+    for ( l_i2 = l_i; *l_i2 && *l_i2 != ' '; ++l_i2 );
+    if ( (l_i2 - l_i) == 3 && (l_i[1] == '_') ) {
+      if (l_i[0] == 'a' && l_i[2] == 'x') a_x = pos;
+      if (l_i[0] == 'a' && l_i[2] == 'y') a_y = pos;
+      if (l_i[0] == 'a' && l_i[2] == 'z') a_z = pos;
+      if (l_i[0] == 'b' && l_i[2] == 'x') b_x = pos;
+      if (l_i[0] == 'b' && l_i[2] == 'y') b_y = pos;
+      if (l_i[0] == 'b' && l_i[2] == 'z') b_z = pos;
+      if (l_i[0] == 'c' && l_i[2] == 'x') c_x = pos;
+      if (l_i[0] == 'c' && l_i[2] == 'y') c_y = pos;
+      if (l_i[0] == 'c' && l_i[2] == 'z') c_z = pos;
+      if (l_i[0] == 'o' && l_i[2] == 'x') o_x = pos;
+      if (l_i[0] == 'o' && l_i[2] == 'y') o_y = pos;
+      if (l_i[0] == 'o' && l_i[2] == 'z') o_z = pos;
+    }
+    ++pos;
+    l_i = l_i2;
+  }
+
+  int numpos = pos;
+
+  XYZ cell[3], origin;
+
+  for ( pos = 0; pos < numpos; ++pos ) {
+    double tmp;
+    xscFile >> tmp;
+    if ( ! xscFile ){
+      sprintf(msg, "Reading BOX %d extended system file %s! \n",
+              box+1, filename);
+      NAMD_die(msg);
+    }
+    if ( pos == 0 ) firstStep = ulong(tmp);
+    if ( pos == a_x ) cell[0].x = tmp;
+    if ( pos == a_y ) cell[0].y = tmp;
+    if ( pos == a_z ) cell[0].z = tmp;
+    if ( pos == b_x ) cell[1].x = tmp;
+    if ( pos == b_y ) cell[1].y = tmp;
+    if ( pos == b_z ) cell[1].z = tmp;
+    if ( pos == c_x ) cell[2].x = tmp;
+    if ( pos == c_y ) cell[2].y = tmp;
+    if ( pos == c_z ) cell[2].z = tmp;
+    if ( pos == o_x ) origin.x = tmp;
+    if ( pos == o_y ) origin.y = tmp;
+    if ( pos == o_z ) origin.z = tmp;
+  }
+
+
+  sprintf(msg, "Info: Finished reading BOX %d extended system file %s \n", box+1, filename);
+  std::cout << msg << std::endl;
+
+  hasCellBasis[box] = true;
+  center[box] = origin;
+  cellBasis[box].Set(0, cell[0]);
+  cellBasis[box].Set(1, cell[1]);
+  cellBasis[box].Set(2, cell[2]);
+  axis.Set(box, cell[0].Length(), cell[1].Length(),
+          cell[2].Length());
+  //Find Cosine Angle of alpha, beta and gamma
+  cosAngle[box][0] = geom::Dot(cellBasis[box].Get(1), cellBasis[box].Get(2)) /
+                    (axis.Get(box).y * axis.Get(box).z);
+  cosAngle[box][1] = geom::Dot(cellBasis[box].Get(0), cellBasis[box].Get(2)) /
+                    (axis.Get(box).x * axis.Get(box).z);
+  cosAngle[box][2] = geom::Dot(cellBasis[box].Get(0), cellBasis[box].Get(1)) /
+                    (axis.Get(box).x * axis.Get(box).y);
+  
+  for(int i = 0; i < 3; i++) {
+    if(cosAngle[box][i] > 1.0) {
+      cosAngle[box][i] = 1.0;
+    }
+    if(cosAngle[box][i] < -1.0) {
+      cosAngle[box][i] = -1.0;
+    }
+    cellAngle[box][i] = acos(cosAngle[box][i]) * 180.0 / M_PI;
+  }
+}
+
+

--- a/src/ExtendedSystem.h
+++ b/src/ExtendedSystem.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+GPU OPTIMIZED MONTE CARLO (GOMC) 2.70
+Copyright (C) 2018  GOMC Group
+A copy of the GNU General Public License can be found in the COPYRIGHT.txt
+along with this program, also can be found at <http://www.gnu.org/licenses/>.
+********************************************************************************/
+#ifndef EXTENDED_SYSTEM
+#define EXTENDED_SYSTEM
+
+#include "InputAbstracts.h" //For FWReadableBase
+#include "BasicTypes.h" //For uint
+#include "EnsemblePreprocessor.h" //For BOX_TOTAL, etc.
+#include "XYZArray.h" //For box dimensions.
+#include "PDBSetup.h"
+#include "GeomLib.h" // for PI and Dot product
+#include <vector>
+
+namespace config_setup
+{
+  struct RestartSettings;
+  struct InFiles;
+  struct Input;
+}
+
+namespace pdb_setup
+{
+  struct Cryst1;
+}
+
+
+class ExtendedSystem  {
+  public:
+  ExtendedSystem();
+  ~ExtendedSystem() {};
+  void Init(PDBSetup &pdb, config_setup::Input inputFiles);
+  private:
+    void ReadExtendedSystem(const char *filename, const int box);
+    void UpdateCellBasis(PDBSetup &pdb, const int box);
+    ulong firstStep;
+    XYZ center[BOX_TOTAL];
+    XYZArray cellBasis[BOX_TOTAL];
+    XYZArray axis;
+    double cosAngle[BOX_TOTAL][3];
+    double cellAngle[BOX_TOTAL][3];
+    bool hasCellBasis[BOX_TOTAL];
+};
+
+
+#endif /*EXTENDED_SYSTEM*/

--- a/src/ExtendedSystem.h
+++ b/src/ExtendedSystem.h
@@ -34,14 +34,25 @@ class ExtendedSystem  {
   ~ExtendedSystem() {};
   void Init(PDBSetup &pdb, config_setup::Input inputFiles);
   private:
+    // Reads the xsc file and store/calculate cellBasis data
     void ReadExtendedSystem(const char *filename, const int box);
+    // Updates the cellBasis data in pdb data structure
     void UpdateCellBasis(PDBSetup &pdb, const int box);
+    // Reads the binary coordinates and updates the X Y Z coordinates in pdb data structure
+    void UpdateCoordinate(PDBSetup &pdb, const char *filename, const int box);
+    // the time steps in xsc file
     ulong firstStep;
+    // Center of cell, but GOMC always uses 0 center
     XYZ center[BOX_TOTAL];
+    // Cell basis vector
     XYZArray cellBasis[BOX_TOTAL];
+    // Cell length
     XYZArray axis;
+    // Cos values of alpha, beta, gamma
     double cosAngle[BOX_TOTAL][3];
+    // Cell angle (alpha, beta, gamma)
     double cellAngle[BOX_TOTAL][3];
+    // Check to see if xsc is defined
     bool hasCellBasis[BOX_TOTAL];
 };
 

--- a/src/PDBSetup.cpp
+++ b/src/PDBSetup.cpp
@@ -29,6 +29,9 @@ void Remarks::SetRestart(config_setup::RestartSettings const& r )
 {
   restart = r.enable;
   recalcTrajectory = r.recalcTrajectory;
+  restartFromXSC = r.restartFromXSCFile;
+  restartFromBinary = r.restartFromBinaryFile;
+
   for(uint b = 0; b < BOX_TOTAL; b++) {
     if(recalcTrajectory)
       reached[b] = false;
@@ -49,7 +52,10 @@ void Remarks::Read(FixedWidthReader & pdb)
     .Get(rotate[currBox], rot::POS)
     .Get(vol[currBox], vol::POS);
 
-    CheckGOMC(varName);
+    if(!restartFromXSC && !restartFromBinary){
+      //only check for file format, if we are not reading from binary files
+      CheckGOMC(varName);
+    }
   }
   if(recalcTrajectory) {
     std::string varName;
@@ -85,7 +91,7 @@ void Cryst1::Read(FixedWidthReader & pdb)
 {
   XYZ temp;
   using namespace pdb_entry::cryst1::field;
-  hasVolume = true;
+  hasVolume[currBox] = true;
   pdb.Get(temp.x, x::POS)
   .Get(temp.y, y::POS)
   .Get(temp.z, z::POS)

--- a/src/PDBSetup.cpp
+++ b/src/PDBSetup.cpp
@@ -52,10 +52,8 @@ void Remarks::Read(FixedWidthReader & pdb)
     .Get(rotate[currBox], rot::POS)
     .Get(vol[currBox], vol::POS);
 
-    if(!restartFromXSC && !restartFromBinary){
-      //only check for file format, if we are not reading from binary files
-      CheckGOMC(varName);
-    }
+    CheckGOMC(varName);
+    
   }
   if(recalcTrajectory) {
     std::string varName;
@@ -118,6 +116,7 @@ void Atoms::Assign(std::string const& atomName,
   //box.push_back((bool)(restart?(uint)(l_occ):currBox));
   beta.push_back(l_beta);
   box.push_back(currBox);
+  ++numAtomsInBox[currBox];
   atomAliases.push_back(atomName);
   resNamesFull.push_back(resName);
   /* Format Atom previously expected resID to start at 0.  We will subtract 1 here to

--- a/src/PDBSetup.h
+++ b/src/PDBSetup.h
@@ -65,7 +65,8 @@ private:
 struct Cryst1 : FWReadableBase {
   //box dimensions
   uint currBox;
-  bool hasVolume[BOX_TOTAL], hasCellBasis[BOX_TOTAL];
+  bool hasVolume[BOX_TOTAL];    //If reads cellBasis info from PDB
+  bool hasCellBasis[BOX_TOTAL]; //If reads cellBasis info from XSC
   XYZArray axis, cellBasis[BOX_TOTAL];
   double cellAngle[BOX_TOTAL][3];
   Cryst1(void) : currBox(0), axis(BOX_TOTAL) 
@@ -88,7 +89,12 @@ class Atoms : public FWReadableBase
 public:
   //Set the current residue to something other than 1
   Atoms(void) : restart(false), currBox(0), count(0),
-    currRes(10) {}
+    currRes(10)
+    {
+      for (int b = 0; b < BOX_TOTAL; b++) {
+        numAtomsInBox[b] = 0;
+      }
+    }
   void SetRestart(config_setup::RestartSettings const& r);
   void SetBox(const uint b)
   {
@@ -123,6 +129,7 @@ public:
   //(restart), count allows overwriting of coordinates during
   //second box read (restart only)
   uint currBox, count, currRes;
+  uint numAtomsInBox[BOX_TOTAL]; // number of atom in each box
   std::string currResname;
 
   uint lastAtomIndexInBox0 = 0;

--- a/src/PDBSetup.h
+++ b/src/PDBSetup.h
@@ -27,11 +27,25 @@ namespace pdb_setup
 {
 struct Remarks : FWReadableBase {
   uint currBox;
-  double  disp[BOX_TOTAL], rotate[BOX_TOTAL], vol[BOX_TOTAL];
+  double disp[BOX_TOTAL], rotate[BOX_TOTAL], vol[BOX_TOTAL];
   ulong step[BOX_TOTAL];
   uint frameNumber[BOX_TOTAL], targetFrame[BOX_TOTAL];
   std::vector<ulong> frameSteps;
   bool restart, reached[BOX_TOTAL], recalcTrajectory;
+  bool restartFromXSC, restartFromBinary;
+  Remarks () {
+    currBox = 0;
+    restart = recalcTrajectory = false;
+    restartFromXSC = restartFromBinary = false;
+    for (int b = 0; b < BOX_TOTAL; b++) {
+      reached[b] = false;
+      frameNumber[b] = targetFrame[b] = 0;
+      //set to -1, so in Movesetting, we initialize it
+      disp[b] = rotate[b] = vol[b] = -1.0; 
+      step[b] = 0;
+    }
+  }
+
   void SetRestart(config_setup::RestartSettings const& r);
   void Read(FixedWidthReader & pdb);
   void SetBox(const uint b)
@@ -51,10 +65,17 @@ private:
 struct Cryst1 : FWReadableBase {
   //box dimensions
   uint currBox;
-  bool hasVolume;
-  XYZArray axis;
+  bool hasVolume[BOX_TOTAL], hasCellBasis[BOX_TOTAL];
+  XYZArray axis, cellBasis[BOX_TOTAL];
   double cellAngle[BOX_TOTAL][3];
-  Cryst1(void) : currBox(0), hasVolume(false), axis(BOX_TOTAL) {}
+  Cryst1(void) : currBox(0), axis(BOX_TOTAL) 
+  {
+    for(int b = 0; b < BOX_TOTAL; b++) {
+      hasCellBasis[b] = false;
+      hasVolume[b] = false;
+      cellBasis[b] = XYZArray(3);
+    }
+  }
   void SetBox(const uint b)
   {
     currBox = b;

--- a/src/Setup.h
+++ b/src/Setup.h
@@ -15,6 +15,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "PDBSetup.h"
 #include "PRNGSetup.h"
 #include "MolSetup.h"
+#include "ExtendedSystem.h"
 #include "GOMC_Config.h"    //For PT
 #include "ParallelTemperingPreprocessor.h"
 class Setup
@@ -23,8 +24,9 @@ public:
   //Read order follows each item
   ConfigSetup config;  //1
   PDBSetup pdb;        //2
-  FFSetup ff;          //3
-  PRNGSetup prng;      //4
+  ExtendedSystem xsc;  //3
+  FFSetup ff;          //4
+  PRNGSetup prng;      //5
 #if GOMC_LIB_MPI
   PRNGSetup prngParallelTemp;      //4
 #endif
@@ -38,6 +40,8 @@ public:
     ff.Init(config.in.files.param.name, config.in.ffKind.isCHARMM);
     //Read PDB data
     pdb.Init(config.in.restart, config.in.files.pdb.name);
+    //Read extended system file to override the cellBasis data
+    xsc.Init(pdb, config.in);
     //Initialize PRNG
     prng.Init(config.in.restart, config.in.prng, config.in.files.seed.name);
 #if GOMC_LIB_MPI

--- a/src/Setup.h
+++ b/src/Setup.h
@@ -38,9 +38,10 @@ public:
     config.Init(configFileName, multisim);
     //Read in FF data.
     ff.Init(config.in.files.param.name, config.in.ffKind.isCHARMM);
-    //Read PDB data
+    //Read in PDB data
     pdb.Init(config.in.restart, config.in.files.pdb.name);
-    //Read extended system file to override the cellBasis data
+    //Read in extended system file to override the cellBasis data
+    //Read in binary coordinate file to override the coordinates data
     xsc.Init(pdb, config.in);
     //Initialize PRNG
     prng.Init(config.in.restart, config.in.prng, config.in.files.seed.name);


### PR DESCRIPTION
This pull request enables GOMC to read in restart binary coordinates (**.coor**) and restart extended system file/s (**.xsc**). #253 

- The restart **xsc** file will override the cellbasis vector defined in coonfig file and cell length and angle stored in restart **pdb** file/s.
- The restart binary **coor**  will override the coordinates stored in restart **pdb** file/s.

### Config File Parameters:
- Use **extendedSystem**, followed by box number, and restart extended system file name (**.xsc**).
  e.g. `extendedSystem 0 Eq_BOX_0_restart.xsc`
- Use **binCoordinates**, followed by box number, and restart binary file name (**.coor**).
  e.g. `binCoordinates 0 Eq_BOX_0_restart.coor`

### Important Note:
- Reading the restart extended system file (**.xsc**) and restart binary coordinates (**.coor**) are decoupled. Hence, user can
  define either or both files.
- To override the coordinates, using outputted binary file, the restart **pdb** file **must be defined and read**.
 e.g.
```
Coordinates 0   ./eq/Adsorption_BOX_0_restart.pdb
Coordinates 1   ./eq/Adsorption_BOX_1_restart.pdb

extendedSystem 0 ./eq/Adsorption_BOX_0.xsc
extendedSystem 1 ./eq/Adsorption_BOX_1.xsc

binCoordinates 0    ./eq/Adsorption_BOX_0_restart.coor
binCoordinates 1    ./eq/Adsorption_BOX_1_restart.coor
```