### PR TITLE
Reading Multi parameter files

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -67,7 +67,6 @@ ConfigSetup::ConfigSetup(void)
   in.ffKind.numOfKinds = 0;
   sys.exclude.EXCLUDE_KIND = UINT_MAX;
   in.prng.kind = "";
-  in.files.param.name = "";
   for(i = 0; i < BOX_TOTAL; i++) {
     in.files.pdb.name[i] = "";
     in.files.psf.name[i] = "";
@@ -242,8 +241,9 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
         printf("%-40s %-s \n", "Info: PARAMETER file", "MARTINI using CHARMM format!");
       }
     } else if(CheckString(line[0], "Parameters")) {
-      in.files.param.name = line[1];
-      in.files.param.defined = true;
+      if(line.size() > 1){
+        in.files.param.push_back(config_setup::FileName(line[1], true));
+      }
     } else if(CheckString(line[0], "Coordinates")) {
       uint boxnum = stringtoi(line[1]);
       if(boxnum >= BOX_TOTAL) {
@@ -1481,7 +1481,7 @@ void ConfigSetup::verifyInputs(void)
       (sys.exclude.EXCLUDE_KIND == sys.exclude.EXC_ONETHREE_KIND)) {
     std::cout << "Warning: Exclude 1-3 is set for EXOTIC type parameter.\n";
   }
-  if(!in.files.param.defined) {
+  if(!in.files.param.size()) {
     std::cout << "Error: Parameter file name is not specified!" << std::endl;
     exit(EXIT_FAILURE);
   }

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -45,7 +45,12 @@ struct FileName {
   std::string name;
   bool defined;
   FileName(void) {
-    defined = false; 
+    defined = false;
+    name = ""; 
+  }
+  FileName(std::string file, bool def) {
+    defined = def;
+    name = file; 
   }
 };
 
@@ -104,7 +109,7 @@ struct FFKind {
 
 //Files for input.
 struct InFiles {
-  FileName param;
+  std::vector<FileName> param;
   FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput;
   FileName seed;
 };

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -60,48 +60,53 @@ FFSetup::SetReadFunctions(const bool isCHARMM)
   return funct;
 }
 
-void FFSetup::Init(std::string const& name, const bool isCHARMM)
+void FFSetup::Init(const std::vector<config_setup::FileName> & fileName, const bool isCHARMM)
 {
   sectKind = SetReadFunctions(isCHARMM);
   std::string currSectName = "", varName = "";
   std::string commentChar = "*!";
   std::string commentStr = "REMARK ATOM ATOMS MASS set AEXP REXP HAEX AAEX NBOND "
                            "CUTNB END CTONN EPS VSWI NBXM INHI";
-  std::map<std::string, ReadableBaseWithFirst *>::const_iterator sect, currSect;
 
-  Reader param(name,
-               paramFileAlias[isCHARMM ? CHARMM_ALIAS_IDX : EXOTIC_ALIAS_IDX],
-               true, &commentStr, true, &commentChar);
-  param.open();
-  while (param.Read(varName)) {
-    sect = sectKind.find(varName);
-    if ( sect != sectKind.end() ) {
-      param.SkipLine(); //Skip rest of line for sect. heading
-      currSectName = varName;
-      currSect = sect; //Save for later calls.
-      std::cout << "Reading " << currSectName << " parameters.\n";
-      if (isCHARMM) {
-        if (hasEnding(currSectName, "MIE")) {
-          std::cout << "Error: CHARMM-Style parameter is set but EXOTIC-Style parameter header " << currSectName << " was found.\n"
-                    "       Either set EXOTIC-Style in config file or change the keyword\n"
-                    "       " << currSectName << " to " << currSectName.substr(0, currSectName.size() - 4) << " in the parameter files.\n";
-          exit(EXIT_FAILURE);
+  for(int p = 0; p < fileName.size(); p++) {
+    std::string name = fileName[p].name;
+
+    std::map<std::string, ReadableBaseWithFirst *>::const_iterator sect, currSect;
+
+    Reader param(name,
+                paramFileAlias[isCHARMM ? CHARMM_ALIAS_IDX : EXOTIC_ALIAS_IDX],
+                true, &commentStr, true, &commentChar);
+    param.open();
+    while (param.Read(varName)) {
+      sect = sectKind.find(varName);
+      if ( sect != sectKind.end() ) {
+        param.SkipLine(); //Skip rest of line for sect. heading
+        currSectName = varName;
+        currSect = sect; //Save for later calls.
+        std::cout << "Reading " << currSectName << " parameters.\n";
+        if (isCHARMM) {
+          if (hasEnding(currSectName, "MIE")) {
+            std::cout << "Error: CHARMM-Style parameter is set but EXOTIC-Style parameter header " << currSectName << " was found.\n"
+                      "       Either set EXOTIC-Style in config file or change the keyword\n"
+                      "       " << currSectName << " to " << currSectName.substr(0, currSectName.size() - 4) << " in the parameter files.\n";
+            exit(EXIT_FAILURE);
+          }
+        } else {
+          std::regex nbonded ("NONBONDED");
+          std::regex nbfix ("NBFIX");
+          if (std::regex_match(currSectName, nbonded) || std::regex_match(currSectName, nbfix)) {
+            std::cout << "Error: EXOTIC-Style parameter is set but CHARMM-Style parameter header " << currSectName << " was found.\n"
+                      "       Either set CHARMM-Style in config file or change the keyword\n"
+                      "       " << currSectName << " to " << currSectName.append("_MIE") << " in the parameter files.\n";
+            exit(EXIT_FAILURE);
+          }
         }
-      } else {
-        std::regex nbonded ("NONBONDED");
-        std::regex nbfix ("NBFIX");
-        if (std::regex_match(currSectName, nbonded) || std::regex_match(currSectName, nbfix)) {
-          std::cout << "Error: EXOTIC-Style parameter is set but CHARMM-Style parameter header " << currSectName << " was found.\n"
-                    "       Either set CHARMM-Style in config file or change the keyword\n"
-                    "       " << currSectName << " to " << currSectName.append("_MIE") << " in the parameter files.\n";
-          exit(EXIT_FAILURE);
-        }
-      }
-    } else
-      currSect->second->Read(param, varName);
+      } else
+        currSect->second->Read(param, varName);
+    }
+
+    param.close();
   }
-
-  param.close();
 
   //check if we read nonbonded parameter
   if(mie.sigma.size() == 0) {

--- a/src/FFSetup.h
+++ b/src/FFSetup.h
@@ -17,7 +17,12 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "FFConst.h" //for forcefield constants
 #include "BasicTypes.h" //for uint
 #include "InputFileReader.h"
+#include "ConfigSetup.h" //for access to structure
 
+namespace config_setup
+{
+  struct FileName;
+}
 
 namespace ff_setup
 {
@@ -287,7 +292,7 @@ class FFSetup
 {
 public:
   FFSetup(void) {}
-  void Init(std::string const& fileName, const bool isCHARMM);
+  void Init(const std::vector<config_setup::FileName> &fileName, const bool isCHARMM);
 
   ff_setup::Particle mie;
   ff_setup::NBfix nbfix;

--- a/src/Setup.h
+++ b/src/Setup.h
@@ -37,7 +37,7 @@ public:
     //Read in all config data
     config.Init(configFileName, multisim);
     //Read in FF data.
-    ff.Init(config.in.files.param.name, config.in.ffKind.isCHARMM);
+    ff.Init(config.in.files.param, config.in.ffKind.isCHARMM);
     //Read in PDB data
     pdb.Init(config.in.restart, config.in.files.pdb.name);
     //Read in extended system file to override the cellBasis data


### PR DESCRIPTION
GOMC can now read multiple parameter files. 

### Confil file:
- Define multiple parameter files: e.g.
```
Parameters     ../../common/Par_PCN14_Noble_Gases_Charmm.inp
Parameters     ../../common/Par_TraPPE_Alkanes_CHARMM.inp

```