### PR TITLE
Fix to ERROR: Error closing DCD file` at the end of simulation

### DIFF
--- a/src/DCDOutput.h
+++ b/src/DCDOutput.h
@@ -42,8 +42,9 @@ public:
     }
 
     for (uint b = 0; b < BOX_TOTAL; ++b) {
-      close_dcd_write(stateFileFileid[b]);
-      xstFile[b].close();
+      if(enableStateOut) {
+        close_dcd_write(stateFileFileid[b]);
+      }
       if(restartCoor[b]) {
         delete [] restartCoor[b];
       }


### PR DESCRIPTION
The issue was closing the dcd file in class destructor, while we have not opened any file to write DCD.