### PR TITLE
Fixed psf restart headers

### DIFF
--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -145,7 +145,7 @@ void PSFOutput::CountMoleculesInBoxes()
       boxAtoms[b] += molKind.NumAtoms() * molLookRef.NumKindInBox(k, b);
       boxBonds[b] += molKind.NumBonds() * molLookRef.NumKindInBox(k, b);
       boxAngles[b] += molKind.NumAngles() * molLookRef.NumKindInBox(k, b);
-      boxDihs[b]s += molKind.NumDihs() * molLookRef.NumKindInBox(k, b);
+      boxDihs[b] += molKind.NumDihs() * molLookRef.NumKindInBox(k, b);
 
       atomT += molLookRef.NumKindInBox(k, b);
     }

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -89,6 +89,7 @@ void PSFOutput::DoOutput(const ulong step)
       return;
     }    
     fprintf(outfile, "PSF\n\n");
+    CountMoleculesInBoxes();
     PrintRemarksInBox(outfile, b);
     PrintAtomsInBox(outfile, b);
     PrintBondsInBox(outfile, b);
@@ -123,6 +124,28 @@ void PSFOutput::CountMolecules()
       totalBonds += molKind.NumBonds() * molLookRef.NumKindInBox(k, b);
       totalAngles += molKind.NumAngles() * molLookRef.NumKindInBox(k, b);
       totalDihs += molKind.NumDihs() * molLookRef.NumKindInBox(k, b);
+
+      atomT += molLookRef.NumKindInBox(k, b);
+    }
+  }
+}
+
+void PSFOutput::CountMoleculesInBoxes()
+{
+  uint atomT = 0;
+
+  for(uint b = 0; b < BOX_TOTAL; b++) {
+    boxAtoms[b] = 0;
+    boxBonds[b] = 0;
+    boxAngles[b] = 0;
+    boxDihs[b] = 0;
+    for(uint k = 0; k < molKinds.size(); ++k) {
+      const MoleculeKind& molKind = molecules->GetKind(atomT);
+
+      boxAtoms[b] += molKind.NumAtoms() * molLookRef.NumKindInBox(k, b);
+      boxBonds[b] += molKind.NumBonds() * molLookRef.NumKindInBox(k, b);
+      boxAngles[b] += molKind.NumAngles() * molLookRef.NumKindInBox(k, b);
+      boxDihs[b]s += molKind.NumDihs() * molLookRef.NumKindInBox(k, b);
 
       atomT += molLookRef.NumKindInBox(k, b);
     }
@@ -276,13 +299,13 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
     std::vector<std::string> remarks;
     std::string boxSpecific;
     //default file remarks
-    remarks.push_back("Combined PSF produced by GOMC");
+    remarks.push_back("Restart PSF produced by GOMC");
     boxSpecific = std::string("Contains Geometry data for molecules in Box " + std::to_string(b));
     remarks.push_back(boxSpecific);
     PrintRemarks(outfile, remarks);
   }
   void PSFOutput::PrintAtomsInBox(FILE* outfile, uint b) const {
-    fprintf(outfile, headerFormat, totalAtoms, atomHeader);
+    fprintf(outfile, headerFormat, boxAtoms[b], atomHeader);
     //silly psfs index from 1
     uint atomID = 1;
     uint resID = 1;
@@ -319,7 +342,7 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
   fputc('\n', outfile);
   }
   void PSFOutput::PrintBondsInBox(FILE* outfile, uint b) const {
-    fprintf(outfile, headerFormat, totalBonds, bondHeader);
+    fprintf(outfile, headerFormat, boxBonds[b], bondHeader);
     uint atomID = 1;
     uint lineEntry = 0;
     for( MoleculeLookup::box_iterator thisMol = molLookRef.BoxBegin(b); thisMol != molLookRef.BoxEnd(b); thisMol++){
@@ -338,7 +361,7 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
     fputs("\n\n", outfile);
   }
   void PSFOutput::PrintAnglesInBox(FILE* outfile, uint b) const {
-    fprintf(outfile, headerFormat, totalAngles, angleHeader);
+    fprintf(outfile, headerFormat, boxAngles[b], angleHeader);
     uint atomID = 1;
     uint lineEntry = 0;
     for( MoleculeLookup::box_iterator thisMol = molLookRef.BoxBegin(b); thisMol != molLookRef.BoxEnd(b); thisMol++){
@@ -358,7 +381,7 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
     fputs("\n\n", outfile);
   }
   void PSFOutput::PrintDihedralsInBox(FILE* outfile, uint b) const {  
-    fprintf(outfile, headerFormat, totalDihs, dihedralHeader);
+    fprintf(outfile, headerFormat, boxDihs[b], dihedralHeader);
     uint atomID = 1;
     uint lineEntry = 0;
     for( MoleculeLookup::box_iterator thisMol = molLookRef.BoxBegin(b); thisMol != molLookRef.BoxEnd(b); thisMol++){

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -50,6 +50,11 @@ private:
   uint totalAngles;
   uint totalDihs;
 
+  uint boxAtoms[BOX_TOTAL];
+  uint boxBonds[BOX_TOTAL];
+  uint boxAngles[BOX_TOTAL];
+  uint boxDihs[BOX_TOTAL];
+
   void PrintRemarks(FILE* outfile, const std::vector<std::string>& remarks) const;
   void PrintAtoms(FILE* outfile) const;
   void PrintBonds(FILE* outfile) const;
@@ -63,6 +68,7 @@ private:
   void PrintDihedralsInBox(FILE* outfile, uint b) const;
 
   void CountMolecules();
+  void CountMoleculesInBoxes();
 
   //NEW_RESTART_CODE
   FILE * outRebuildRestart[BOX_TOTAL];


### PR DESCRIPTION
This commit calculates the correct number of atoms, bonds, angles, and dihedrals for a split psf restart file and includes it in the header.