### PR TITLE
added the extra terms namd requires at the end of a psf file (imprope…

### DIFF
--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -213,7 +213,8 @@ std::vector<Bond> mol_setup::BondsAll(const MolKind& molKind)
 int mol_setup::ReadCombinePSF(MolMap& kindMap,
                               SizeMap& sizeMap,
                               std::string const*const psfFilename,
-                              const int numFiles, pdb_setup::Atoms& pdbAtoms)
+                              const bool* psfDefined, 
+                              pdb_setup::Atoms& pdbAtoms)
 {
   int errorcode = ReadPSF(psfFilename[0].c_str(), kindMap, sizeMap, pdbAtoms);
   int nAtoms = errorcode;
@@ -221,9 +222,9 @@ int mol_setup::ReadCombinePSF(MolMap& kindMap,
     return errorcode;
   MolMap map2;
   SizeMap sizeMap2;
-  for (int i = 1; i < numFiles; ++i) {
+  if (pdbAtoms.count != nAtoms && BOX_TOTAL == 2 && psfDefined[1]) {    
     map2.clear();
-    errorcode = ReadPSF(psfFilename[i].c_str(), map2, sizeMap2, pdbAtoms, &kindMap, &sizeMap);
+    errorcode = ReadPSF(psfFilename[1].c_str(), map2, sizeMap2, pdbAtoms, &kindMap, &sizeMap);
     nAtoms += errorcode;
     if (errorcode < 0)
       return errorcode;
@@ -242,17 +243,13 @@ int mol_setup::ReadCombinePSF(MolMap& kindMap,
   return 0;
 }
 int MolSetup::Init(const config_setup::RestartSettings& restart,
-                   const std::string* psfFilename, pdb_setup::Atoms& pdbAtoms)
+                   const std::string* psfFilename, 
+                   const bool* psfDefined, 
+                   pdb_setup::Atoms& pdbAtoms)
 {
   kindMap.clear();
   sizeMap.clear();
-  int numFiles;
-  if(restart.enable)
-    numFiles = 1;
-  else
-    numFiles = BOX_TOTAL;
-
-  return ReadCombinePSF(kindMap, sizeMap, psfFilename, numFiles, pdbAtoms);
+  return ReadCombinePSF(kindMap, sizeMap, psfFilename, psfDefined, pdbAtoms);
 }
 
 

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -147,7 +147,7 @@ typedef std::map<std::size_t, std::vector<std::string> > SizeMap;
 *\return -1 if failed, 0 if successful
 */
 int ReadCombinePSF(MolMap& kindMap, SizeMap& sizeMap, const std::string* psfFilename,
-                   const int numFiles, pdb_setup::Atoms& pdbAtoms);
+                   const bool* psfDefined, pdb_setup::Atoms& pdbAtoms);
 
 void PrintMolMapVerbose(const MolMap& kindMap);
 void PrintMolMapBrief(const MolMap& kindMap);
@@ -174,7 +174,9 @@ public:
   //reads BoxTotal PSFs and merges the data, placing the results in kindMap
   //returns 0 if read is successful, -1 on a failure
   int Init(const config_setup::RestartSettings& restart,
-           const std::string* psfFilename, pdb_setup::Atoms& pdbAtoms);
+           const std::string* psfFilename, 
+           const bool* psfDefined, 
+           pdb_setup::Atoms& pdbAtoms);
 
   void AssignKinds(const pdb_setup::Atoms& pdbAtoms, const FFSetup& ffData);
 

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -18,6 +18,11 @@ const char* atomHeader = "!NATOM";
 const char* bondHeader = "!NBOND: bonds";
 const char* angleHeader = "!NTHETA: angles";
 const char* dihedralHeader = "!NPHI: dihedrals";
+const char* improperHeader = "!NIMPHI: impropers";
+const char* donorHeader = "!NDON: donors";
+const char* acceptorHeader = "!NACC: acceptors";
+const char* excludedHeader = "!NNB";
+const char* groupHeader = "!NGRP";
 
 const char* headerFormat = "%8d %s \n";
 //atom ID, segment name, residue ID, residue name,
@@ -95,6 +100,7 @@ void PSFOutput::DoOutput(const ulong step)
     PrintBondsInBox(outfile, b);
     PrintAnglesInBox(outfile, b);
     PrintDihedralsInBox(outfile, b);
+    PrintNAMDCompliantSuffixInBox(outfile, b);
     fclose(outfile);
   }
 }
@@ -176,6 +182,7 @@ void PSFOutput::PrintPSF(const std::string& filename,
   PrintBonds(outfile);
   PrintAngles(outfile);
   PrintDihedrals(outfile);
+  PrintNAMDCompliantSuffix(outfile);
   fclose(outfile);
 }
 
@@ -217,6 +224,8 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
       }
       ++atomID;
     }
+    /* This isn't actually residue, it is running count of the number of
+      molecule kinds we have printed */
     ++resID;
     /* To add additional intramolecular residues */
     if (molKinds[thisKind].isMultiResidue){
@@ -295,6 +304,18 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
   fputs("\n\n", outfile);
 }
 
+  void PSFOutput::PrintNAMDCompliantSuffix(FILE* outfile) const {
+    fprintf(outfile, headerFormat, 0, improperHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, donorHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, acceptorHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, excludedHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, groupHeader);
+  }
+
   void PSFOutput::PrintRemarksInBox(FILE* outfile, uint b) const {
     std::vector<std::string> remarks;
     std::string boxSpecific;
@@ -338,8 +359,8 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
     // ???
       if(resID == 10000)
         resID = 1;
-  }
-  fputc('\n', outfile);
+    }
+    fputc('\n', outfile);
   }
   void PSFOutput::PrintBondsInBox(FILE* outfile, uint b) const {
     fprintf(outfile, headerFormat, boxBonds[b], bondHeader);
@@ -400,4 +421,16 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
       atomID += thisKind.atoms.size();
     }
     fputs("\n\n", outfile);
+  }
+
+  void PSFOutput::PrintNAMDCompliantSuffixInBox(FILE* outfile, uint b) const {
+    fprintf(outfile, headerFormat, 0, improperHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, donorHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, acceptorHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, excludedHeader);
+    fputs("\n\n", outfile);
+    fprintf(outfile, headerFormat, 0, groupHeader);
   }

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -67,6 +67,9 @@ private:
   void PrintAnglesInBox(FILE* outfile, uint b) const;
   void PrintDihedralsInBox(FILE* outfile, uint b) const;
 
+  void PrintNAMDCompliantSuffix(FILE* outfile) const;
+  void PrintNAMDCompliantSuffixInBox(FILE* outfile, uint b) const;
+
   void CountMolecules();
   void CountMoleculesInBoxes();
 

--- a/src/Setup.h
+++ b/src/Setup.h
@@ -57,7 +57,7 @@ public:
             to serve as a multiresidue molecule entry into the kindMap containing
             all these residues.  This is as upstream as possible to change as little code
             as necessary */
-    if(mol.Init(config.in.restart, config.in.files.psf.name, pdb.atoms) != 0) {
+    if(mol.Init(config.in.restart, config.in.files.psf.name, config.in.files.psf.defined, pdb.atoms) != 0) {
       exit(EXIT_FAILURE);
     }
     mol.AssignKinds(pdb.atoms, ff);


### PR DESCRIPTION
…rs, nnb, ngrp).  Also added some logic to parse a second psf file if we need it, instead of relying on the restart flag to tell us how many psf flags to parse.  We only parse if the first psf file we readed doesn't contain all the atoms in the pdb file, (also a second psf file has to exist).