### PR TITLE
Changed how we retrieve a moleculeKind.  Instead of indexing into the…

### DIFF
--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -481,6 +481,7 @@ void createMapAndModifyPDBAtomDataStructure(const BondAdjacencyList & bondAdjLis
             pdbAtoms.resKinds.push_back(kindMap[*sizeConsistentEntries].kindIndex);
             pdbAtoms.resNames.push_back(*sizeConsistentEntries);
             newMapEntry = false;
+            break;
           }
         }
       }
@@ -496,9 +497,6 @@ void createMapAndModifyPDBAtomDataStructure(const BondAdjacencyList & bondAdjLis
             break;
           }
         }
-      }
-
-      if (newMapEntry){
         if(multiResidue){  
           std::stringstream ss;
           /* Length of Suffix */

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -124,7 +124,10 @@ void PSFOutput::CountMolecules()
 
   for(uint b = 0; b < BOX_TOTAL; b++) {
     for(uint k = 0; k < molKinds.size(); ++k) {
-      const MoleculeKind& molKind = molecules->GetKind(atomT);
+      // This doesnt work when the molecules are interspersed instead of all of one type then all the other
+      //const MoleculeKind& molKind = molecules->GetKind(atomT);
+
+      const MoleculeKind& molKind = molecules->kinds[k];
 
       totalAtoms += molKind.NumAtoms() * molLookRef.NumKindInBox(k, b);
       totalBonds += molKind.NumBonds() * molLookRef.NumKindInBox(k, b);
@@ -146,7 +149,9 @@ void PSFOutput::CountMoleculesInBoxes()
     boxAngles[b] = 0;
     boxDihs[b] = 0;
     for(uint k = 0; k < molKinds.size(); ++k) {
-      const MoleculeKind& molKind = molecules->GetKind(atomT);
+      // This doesnt work when the molecules are interspersed instead of all of one type then all the other
+      //const MoleculeKind& molKind = molecules->GetKind(atomT);      
+      const MoleculeKind& molKind = molecules->kinds[k];
 
       boxAtoms[b] += molKind.NumAtoms() * molLookRef.NumKindInBox(k, b);
       boxBonds[b] += molKind.NumBonds() * molLookRef.NumKindInBox(k, b);


### PR DESCRIPTION
… master particle array consisting of the array of molecule objects accessed though a method call, _molecules->GetKind(atomT)_, I am using the kind array in the molecule object, _molecules->kinds[k];_.  This allows the input simulations to be more flexible in their setup.  Previously, the system had to be homogenous in the input psf file.  For example, in a binary system the first component, say argon, had to be grouped with all the argons in the system, then the next component, say kr, would be the only molecule in the psf file until EOF or the next box.  This new approach relaxes this constraint.

When building a protein and water simulation for MC-MD testing, I noticed our method for counting the number of molecules requires the molecule types be grouped in the input psf file.

For example

Atom 1 Ar
Atom 2 Ar
Atom 3 Kr
Atom 4 Kr

This patch supports files such as
Atom 1 Ar
Atom 2 Kr
Atom 3 Ar
Atom 4 Kr

Which was a necessary feature to support using packmol and then psfgen to generate a box with multiple copies of a protein and multiple water molecules.