### PR TITLE
Reject swap/intra-swap move for bad configuraiton

### DIFF
--- a/lib/NumLib.h
+++ b/lib/NumLib.h
@@ -17,6 +17,9 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #define DBL_MAX 1.7976931348623158e+308
 #endif
 
+#ifndef SMALL_WEIGHT
+#define SMALL_WEIGHT 1.0e-38
+#endif
 namespace num
 {
 static const double dbl_margin = 0.00001;

--- a/src/moves/IntraSwap.h
+++ b/src/moves/IntraSwap.h
@@ -106,7 +106,7 @@ inline void IntraSwap::CalcEn()
   correct_old = 0.0;
   correct_new = 0.0;
 
-  if (newMol.GetWeight() != 0.0 && !overlap) {
+  if (newMol.GetWeight() > SMALL_WEIGHT && !overlap) {
     correct_new = calcEwald->SwapCorrection(newMol, molIndex);
     correct_old = calcEwald->SwapCorrection(oldMol, molIndex);
     recipDiff.energy = calcEwald->MolReciprocal(newMol.GetCoords(), molIndex,
@@ -129,7 +129,7 @@ inline void IntraSwap::Accept(const uint rejectState, const uint step)
     double Wrat = Wn / Wo * W_tc * W_recip;
 
     //safety to make sure move will be rejected in overlap case
-    if(!overlap) {
+    if(newMol.GetWeight() > SMALL_WEIGHT && !overlap) {
       result = prng() < molTransCoeff * Wrat;
     } else
       result = false;

--- a/src/moves/MoleculeTransfer.h
+++ b/src/moves/MoleculeTransfer.h
@@ -116,7 +116,7 @@ inline void MoleculeTransfer::CalcEn()
     W_tc = exp(-1.0 * ffRef.beta * (tcGain.energy + tcLose.energy));
   }
 
-  if (newMol.GetWeight() != 0.0 && !overlap) {
+  if (newMol.GetWeight() > SMALL_WEIGHT && !overlap) {
     correct_new = calcEwald->SwapCorrection(newMol);
     correct_old = calcEwald->SwapCorrection(oldMol);
     self_new = calcEwald->SwapSelf(newMol);
@@ -176,7 +176,7 @@ inline void MoleculeTransfer::Accept(const uint rejectState, const uint step)
     double Wrat = Wn / Wo * W_tc * W_recip;
 
     //safety to make sure move will be rejected in overlap case
-    if(!overlap) {
+    if(newMol.GetWeight() > SMALL_WEIGHT && !overlap) {
       result = prng() < molTransCoeff * Wrat;
     } else
       result = false;


### PR DESCRIPTION
Change the logic of rejecting the swap or intra-swap move, when new configuration overlaps with other atoms. In new logic, when the Rosenbluth Weight of new configuration falls bellow threshold of 1.0e-38, move is rejected. 