### PR TITLE
Fix #295 MP move needs to use the reference k-vectors

### DIFF
--- a/src/CalculateEnergy.cpp
+++ b/src/CalculateEnergy.cpp
@@ -149,7 +149,7 @@ SystemPotential CalculateEnergy::SystemInter(SystemPotential potential,
     //calculate LJ interaction and real term of electrostatic interaction
     potential = BoxInter(potential, coords, boxAxes, b);
     //calculate reciprocal term of electrostatic interaction
-    potential.boxEnergy[b].recip = calcEwald->BoxReciprocal(b);
+    potential.boxEnergy[b].recip = calcEwald->BoxReciprocal(b, false);
   }
 
   potential.Total();

--- a/src/Ewald.h
+++ b/src/Ewald.h
@@ -67,11 +67,14 @@ public:
   //Get initial estimate of memory required
   void RecipCountInit(uint box, BoxDimensions const& boxAxes);
 
-  //setup reciprocal term for a box
+  //compute reciprocal term for a box with a new volume
   virtual void BoxReciprocalSetup(uint box, XYZArray const& molCoords);
 
+  //compute reciprocal term for a box when not testing a volume change
+  virtual void BoxReciprocalSums(uint box, XYZArray const& molCoords);
+
   //calculate reciprocal energy term for a box
-  virtual double BoxReciprocal(uint box) const;
+  virtual double BoxReciprocal(uint box, bool isNewVolume) const;
 
   //calculate self term for a box
   virtual double BoxSelf(uint box) const;
@@ -120,7 +123,7 @@ public:
   //update reciprocal values
   virtual void UpdateRecip(uint box);
 
-  //update the hx,y,z hsqr and prefact
+  //update kx, ky, kz, hsqr and prefact
   virtual void UpdateRecipVec(uint box);
 
   //calculate self term after swap move
@@ -141,7 +144,7 @@ public:
 
   /// This function performs three actions:
   /// 1. Initialize k vectors
-  /// 2. Run BoxReciprocalSetup to calculate sumRnew and sumInew
+  /// 2. Run BoxReciprocalSetup to calculate sumRnew and sumInew vectors
   /// 3. Then copy all new vectors to ref vectors
   /// @param bool: whether to print the vector size
   virtual void UpdateVectorsAndRecipTerms(bool output);

--- a/src/EwaldCached.cpp
+++ b/src/EwaldCached.cpp
@@ -61,7 +61,7 @@ void EwaldCached::Init()
   }
 
   AllocMem();
-  //initialize K vectors and reciprocate terms
+  //initialize K vectors and reciprocal terms
   UpdateVectorsAndRecipTerms(true);
 }
 
@@ -88,13 +88,15 @@ void EwaldCached::AllocMem()
   }
 }
 
-//calculate reciprocal term for a box
+
+//calculate reciprocal terms for a box. Should be called only at
+//the start of the simulation to initialize the settings and when
+//testing a change in box dimensions, such as a volume transfer.
 void EwaldCached::BoxReciprocalSetup(uint box, XYZArray const& molCoords)
 {
-
   if (box < BOXES_WITH_U_NB) {
-    MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
     MoleculeLookup::box_iterator thisMol = molLookup.BoxBegin(box);
+    MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
 
 #ifdef _OPENMP
     #pragma omp parallel default(none) shared(box)
@@ -110,7 +112,8 @@ void EwaldCached::BoxReciprocalSetup(uint box, XYZArray const& molCoords)
       uint startAtom = mols.MolStart(*thisMol);
 
 #ifdef _OPENMP
-      #pragma omp parallel for default(none) shared(box, lambdaCoef, molCoords, startAtom, thisKind, thisMol)
+      #pragma omp parallel for default(none) shared(box, lambdaCoef, molCoords, \
+      startAtom, thisKind, thisMol)
 #endif
       for (int i = 0; i < (int) imageSize[box]; i++) {
         cosMolRef[*thisMol][i] = 0.0;
@@ -120,9 +123,8 @@ void EwaldCached::BoxReciprocalSetup(uint box, XYZArray const& molCoords)
           if(particleHasNoCharge[startAtom + j]) {
             continue;
           }
-          double dotProduct = Dot(mols.MolStart(*thisMol) + j,
-                                  kx[box][i], ky[box][i],
-                                  kz[box][i], molCoords);
+          double dotProduct = Dot(mols.MolStart(*thisMol) + j, kx[box][i],
+                                  ky[box][i], kz[box][i], molCoords);
           //cache the Cos and sin term with lambda = 1
           cosMolRef[*thisMol][i] += (thisKind.AtomCharge(j) *
                                      cos(dotProduct));
@@ -140,19 +142,92 @@ void EwaldCached::BoxReciprocalSetup(uint box, XYZArray const& molCoords)
 }
 
 
-//calculate reciprocal term for a box
-double EwaldCached::BoxReciprocal(uint box) const
+//Calculate reciprocal terms for a box, when an updated value is needed
+//because the number and location of molecules could have changed since
+//the volume was set. Examples include MultiParticle and Molecule Exchange
+//moves. For these calls, we need to use the Reference settings, since
+//these hold the information for the current box dimensions.
+void EwaldCached::BoxReciprocalSums(uint box, XYZArray const& molCoords)
+{
+  if (box < BOXES_WITH_U_NB) {
+    MoleculeLookup::box_iterator thisMol = molLookup.BoxBegin(box);
+    MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
+
+#ifdef _OPENMP
+    #pragma omp parallel default(none) shared(box)
+#endif
+    {
+      std::memset(sumRnew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+      std::memset(sumInew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+    }
+
+    while (thisMol != end) {
+      MoleculeKind const& thisKind = mols.GetKind(*thisMol);
+      double lambdaCoef = GetLambdaCoef(*thisMol, box);
+      uint startAtom = mols.MolStart(*thisMol);
+
+#ifdef _OPENMP
+      #pragma omp parallel for default(none) shared(box, lambdaCoef, molCoords, \
+      startAtom, thisKind, thisMol)
+#endif
+      for (int i = 0; i < (int) imageSizeRef[box]; i++) {
+        cosMolRef[*thisMol][i] = 0.0;
+        sinMolRef[*thisMol][i] = 0.0;
+
+        for (uint j = 0; j < thisKind.NumAtoms(); j++) {
+          if(particleHasNoCharge[startAtom + j]) {
+            continue;
+          }
+          double dotProduct = Dot(mols.MolStart(*thisMol) + j, kxRef[box][i],
+                                  kyRef[box][i], kzRef[box][i], molCoords);
+          //cache the Cos and sin term with lambda = 1
+          cosMolRef[*thisMol][i] += (thisKind.AtomCharge(j) *
+                                     cos(dotProduct));
+          sinMolRef[*thisMol][i] += (thisKind.AtomCharge(j) *
+                                     sin(dotProduct));
+        }
+        //store the summation with system lambda
+        sumRnew[box][i] += (lambdaCoef * cosMolRef[*thisMol][i]);
+        sumInew[box][i] += (lambdaCoef * sinMolRef[*thisMol][i]);
+      }
+
+      thisMol++;
+    }
+  }
+}
+
+
+//Calculate reciprocal energy for a box. This function is called for two reasons:
+// 1. During a volume move, we call this function to total the sums for the new
+//    volume. For these calls, need to total the sums with the new volume settings.
+// 2. During a Molecule Exchange or MultiParticle move, we need to recompute these
+//    sums for the current volume, since the number and location of molecules
+//    could have changed since the volume was set. For these calls, we need to
+//    use the Reference settings, since these hold the information for the current
+//    box dimensions. Also called at the start of the simulation, after the
+//    Reference volume parameters have been set.
+double EwaldCached::BoxReciprocal(uint box, bool isNewVolume) const
 {
   double energyRecip = 0.0;
 
   if (box < BOXES_WITH_U_NB) {
+    double *prefactPtr;
+    int imageSzVal;
+    if (isNewVolume) {
+      prefactPtr = prefact[box];
+      imageSzVal = static_cast<int>(imageSize[box]);
+    } else {
+      prefactPtr = prefactRef[box];
+      imageSzVal = static_cast<int>(imageSizeRef[box]);
+    }
 #ifdef _OPENMP
-    #pragma omp parallel for default(none) shared(box) reduction(+:energyRecip)
+    #pragma omp parallel for default(none) shared(box, imageSzVal, prefactPtr) \
+    reduction(+:energyRecip)
 #endif
-    for (int i = 0; i < (int) imageSize[box]; i++) {
+    for (int i = 0; i < imageSzVal; i++) {
       energyRecip += ((sumRnew[box][i] * sumRnew[box][i] +
                        sumInew[box][i] * sumInew[box][i]) *
-                       prefact[box][i]);
+                       prefactPtr[i]);
     }
   }
 

--- a/src/EwaldCached.h
+++ b/src/EwaldCached.h
@@ -20,11 +20,14 @@ public:
 
   virtual void AllocMem();
 
-  //setup reciprocal term for a box
+  //compute reciprocal term for a box with a new volume
   virtual void BoxReciprocalSetup(uint box, XYZArray const& molCoords);
 
+  //compute reciprocal term for a box when not testing a volume change
+  virtual void BoxReciprocalSums(uint box, XYZArray const& molCoords);
+
   //calculate reciprocal energy term for a box
-  virtual double BoxReciprocal(uint box) const;
+  virtual double BoxReciprocal(uint box, bool isNewVolume) const;
 
   //calculate reciprocal term for displacement and rotation move
   virtual double MolReciprocal(XYZArray const& molCoords, const uint molIndex,

--- a/src/GPU/CalculateEwaldCUDAKernel.cu
+++ b/src/GPU/CalculateEwaldCUDAKernel.cu
@@ -19,10 +19,12 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 using namespace cub;
 
 #define IMAGES_PER_BLOCK 64
-#define PARTICLE_PER_BLOCK 64
+#define PARTICLES_PER_BLOCK 64
 
 #define FULL_MASK 0xffffffff
 
+//Use this function when calculating the reciprocal terms
+//for a new volume. A change in box dimensions.
 void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
                                XYZArray const &coords,
                                double const *kx,
@@ -38,8 +40,8 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
                                uint box)
 {
   double *gpu_particleCharge;
-  double * gpu_energyRecip;
-  double * gpu_final_energyRecip;
+  double *gpu_energyRecip;
+  double *gpu_final_energyRecip;
   int atomNumber = coords.Count();
 
   CUMALLOC((void**) &gpu_particleCharge,
@@ -50,7 +52,7 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
   cudaMemcpy(gpu_particleCharge, &particleCharge[0],
              particleCharge.size() * sizeof(double),
              cudaMemcpyHostToDevice);
-
+  checkLastErrorCUDA(__FILE__, __LINE__);
   cudaMemcpy(vars->gpu_x, coords.x, atomNumber * sizeof(double),
              cudaMemcpyHostToDevice);
   checkLastErrorCUDA(__FILE__, __LINE__);
@@ -81,8 +83,8 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
   checkLastErrorCUDA(__FILE__, __LINE__);
 
   dim3 threadsPerBlock(256, 1, 1);
-  dim3 blocksPerGrid((int)(imageSize / threadsPerBlock.x) + 1, (int)(atomNumber / PARTICLE_PER_BLOCK) + 1, 1);
-  BoxReciprocalSetupGPU <<< blocksPerGrid, threadsPerBlock>>>(
+  dim3 blocksPerGrid((int)(imageSize / threadsPerBlock.x) + 1, (int)(atomNumber / PARTICLES_PER_BLOCK) + 1, 1);
+  BoxReciprocalSumsGPU <<< blocksPerGrid, threadsPerBlock>>>(
     vars->gpu_x,
     vars->gpu_y,
     vars->gpu_z,
@@ -132,22 +134,115 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
   CUFREE(d_temp_storage);
 }
 
-__global__ void BoxReciprocalSetupGPU(double *gpu_x,
-                                      double *gpu_y,
-                                      double *gpu_z,
-                                      double *gpu_kx,
-                                      double *gpu_ky,
-                                      double *gpu_kz,
-                                      int atomNumber,
-                                      double *gpu_particleCharge,
-                                      double *gpu_sumRnew,
-                                      double *gpu_sumInew,
-                                      int imageSize)
+
+//Use this function when calculating the reciprocal terms
+//with the current volume.
+void CallBoxReciprocalSumsGPU(VariablesCUDA *vars,
+                              XYZArray const &coords,
+                              std::vector<double> particleCharge,
+                              uint imageSize,
+                              double *sumRnew,
+                              double *sumInew,
+                              double &energyRecip,
+                              uint box)
 {
-  __shared__ double shared_coords[PARTICLE_PER_BLOCK * 3];
+  double *gpu_particleCharge;
+  double *gpu_energyRecip;
+  double *gpu_final_energyRecip;
+  int atomNumber = coords.Count();
+
+  CUMALLOC((void**) &gpu_particleCharge,
+           particleCharge.size() * sizeof(double));
+  CUMALLOC((void**) &gpu_energyRecip, imageSize * sizeof(double));
+  CUMALLOC((void**) &gpu_final_energyRecip, sizeof(double));
+
+  cudaMemcpy(gpu_particleCharge, &particleCharge[0],
+             particleCharge.size() * sizeof(double),
+             cudaMemcpyHostToDevice);
+  checkLastErrorCUDA(__FILE__, __LINE__);
+  cudaMemcpy(vars->gpu_x, coords.x, atomNumber * sizeof(double),
+             cudaMemcpyHostToDevice);
+  checkLastErrorCUDA(__FILE__, __LINE__);
+  cudaMemcpy(vars->gpu_y, coords.y, atomNumber * sizeof(double),
+             cudaMemcpyHostToDevice);
+  checkLastErrorCUDA(__FILE__, __LINE__);
+  cudaMemcpy(vars->gpu_z, coords.z, atomNumber * sizeof(double),
+             cudaMemcpyHostToDevice);
+  checkLastErrorCUDA(__FILE__, __LINE__);
+  cudaMemset(vars->gpu_sumRnew[box], 0, imageSize * sizeof(double));
+  checkLastErrorCUDA(__FILE__, __LINE__);
+  cudaMemset(vars->gpu_sumInew[box], 0, imageSize * sizeof(double));
+  checkLastErrorCUDA(__FILE__, __LINE__);
+
+  dim3 threadsPerBlock(256, 1, 1);
+  dim3 blocksPerGrid((int)(imageSize / threadsPerBlock.x) + 1, (int)(atomNumber / PARTICLES_PER_BLOCK) + 1, 1);
+  BoxReciprocalSumsGPU <<< blocksPerGrid, threadsPerBlock>>>(
+    vars->gpu_x,
+    vars->gpu_y,
+    vars->gpu_z,
+    vars->gpu_kxRef[box],
+    vars->gpu_kyRef[box],
+    vars->gpu_kzRef[box],
+    atomNumber,
+    gpu_particleCharge,
+    vars->gpu_sumRnew[box],
+    vars->gpu_sumInew[box],
+    imageSize);
+  cudaDeviceSynchronize();
+  checkLastErrorCUDA(__FILE__, __LINE__);
+
+  //Need just one thread per image for this kernel.
+  blocksPerGrid.y = 1;
+  BoxReciprocalGPU <<< blocksPerGrid, threadsPerBlock>>>(
+    vars->gpu_prefactRef[box],
+    vars->gpu_sumRnew[box],
+    vars->gpu_sumInew[box],
+    gpu_energyRecip,
+    imageSize);
+  cudaDeviceSynchronize();
+  checkLastErrorCUDA(__FILE__, __LINE__);
+
+  cudaMemcpy(sumRnew, vars->gpu_sumRnew[box],
+             imageSize * sizeof(double),
+             cudaMemcpyDeviceToHost);
+  cudaMemcpy(sumInew, vars->gpu_sumInew[box],
+             imageSize * sizeof(double),
+             cudaMemcpyDeviceToHost);
+
+  // ReduceSum
+  void *d_temp_storage = NULL;
+  size_t temp_storage_bytes = 0;
+  DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, gpu_energyRecip,
+                    gpu_final_energyRecip, imageSize);
+  CUMALLOC(&d_temp_storage, temp_storage_bytes);
+  DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, gpu_energyRecip,
+                    gpu_final_energyRecip, imageSize);
+  cudaMemcpy(&energyRecip, gpu_final_energyRecip,
+             sizeof(double), cudaMemcpyDeviceToHost);
+
+  CUFREE(gpu_particleCharge);
+  CUFREE(gpu_energyRecip);
+  CUFREE(gpu_final_energyRecip);
+  CUFREE(d_temp_storage);
+}
+
+
+__global__ void BoxReciprocalSumsGPU(double *gpu_x,
+                                     double *gpu_y,
+                                     double *gpu_z,
+                                     double *gpu_kx,
+                                     double *gpu_ky,
+                                     double *gpu_kz,
+                                     int atomNumber,
+                                     double *gpu_particleCharge,
+                                     double *gpu_sumRnew,
+                                     double *gpu_sumInew,
+                                     int imageSize)
+{
+  __shared__ double shared_coords[PARTICLES_PER_BLOCK * 3];
   int imageID = blockIdx.x * blockDim.x + threadIdx.x;
-  int offset_coordinates_index = blockIdx.y * PARTICLE_PER_BLOCK;
-  int numberOfAtoms = min(PARTICLE_PER_BLOCK, atomNumber - offset_coordinates_index);
+  int offset_coordinates_index = blockIdx.y * PARTICLES_PER_BLOCK;
+  int numberOfAtoms = min(PARTICLES_PER_BLOCK, atomNumber - offset_coordinates_index);
   double sumR = 0.0, sumI = 0.0;
 
   if(threadIdx.x < numberOfAtoms) {
@@ -277,7 +372,7 @@ void CallSwapReciprocalGPU(VariablesCUDA *vars,
                            uint imageSize,
                            double *sumRnew,
                            double *sumInew,
-                           int const insert,
+                           const bool insert,
                            double &energyRecipNew,
                            uint box)
 {
@@ -434,13 +529,13 @@ void CallBoxForceReciprocalGPU(
     qqFact,
     constValue,
     imageSize,
-    vars->gpu_kx[box],
-    vars->gpu_ky[box],
-    vars->gpu_kz[box],
+    vars->gpu_kxRef[box],
+    vars->gpu_kyRef[box],
+    vars->gpu_kzRef[box],
     vars->gpu_x,
     vars->gpu_y,
     vars->gpu_z,
-    vars->gpu_prefact[box],
+    vars->gpu_prefactRef[box],
     vars->gpu_sumRnew[box],
     vars->gpu_sumInew[box],
     vars->gpu_isFraction,
@@ -464,7 +559,7 @@ void CallBoxForceReciprocalGPU(
   cudaMemcpy(molForceRec.z, vars->gpu_mForceRecz, sizeof(double) * molCount, cudaMemcpyDeviceToHost);
 
   cudaDeviceSynchronize();
-  delete [] arr_particleHasNoCharge;
+  delete[] arr_particleHasNoCharge;
   CUFREE(gpu_particleCharge);
   CUFREE(gpu_particleHasNoCharge);
   CUFREE(gpu_particleUsed);
@@ -594,7 +689,7 @@ __global__ void SwapReciprocalGPU(double *gpu_x, double *gpu_y, double *gpu_z,
                                   double *gpu_sumRref,
                                   double *gpu_sumIref,
                                   double *gpu_prefactRef,
-                                  int insert,
+                                  const bool insert,
                                   double *gpu_energyRecipNew,
                                   int imageSize)
 {

--- a/src/GPU/CalculateEwaldCUDAKernel.cuh
+++ b/src/GPU/CalculateEwaldCUDAKernel.cuh
@@ -47,6 +47,15 @@ void CallBoxReciprocalSetupGPU(VariablesCUDA *vars,
                                double &energyRecip,
                                uint box);
 
+void CallBoxReciprocalSumsGPU(VariablesCUDA *vars,
+                              XYZArray const &coords,
+                              std::vector<double> particleCharge,
+                              uint imageSize,
+                              double *sumRnew,
+                              double *sumInew,
+                              double &energyRecip,
+                              uint box);
+
 void CallMolReciprocalGPU(VariablesCUDA *vars,
                           XYZArray const &currentCoords,
                           XYZArray const &newCoords,
@@ -63,7 +72,7 @@ void CallSwapReciprocalGPU(VariablesCUDA *vars,
                            uint imageSize,
                            double *sumRnew,
                            double *sumInew,
-                           int const insert,
+                           const bool insert,
                            double &energyRecipNew,
                            uint box);
 
@@ -104,17 +113,17 @@ __global__ void BoxForceReciprocalGPU(double *gpu_aForceRecx,
                                       int box,
                                       int atomCount);
 
-__global__ void BoxReciprocalSetupGPU(double * gpu_x,
-                                      double * gpu_y,
-                                      double * gpu_z,
-                                      double * gpu_kx,
-                                      double * gpu_ky,
-                                      double * gpu_kz,
-                                      int atomNumber,
-                                      double * gpu_particleCharge,
-                                      double * gpu_sumRnew,
-                                      double * gpu_sumInew,
-                                      int imageSize);
+__global__ void BoxReciprocalSumsGPU(double * gpu_x,
+                                     double * gpu_y,
+                                     double * gpu_z,
+                                     double * gpu_kx,
+                                     double * gpu_ky,
+                                     double * gpu_kz,
+                                     int atomNumber,
+                                     double * gpu_particleCharge,
+                                     double * gpu_sumRnew,
+                                     double * gpu_sumInew,
+                                     int imageSize);
 
 __global__ void MolReciprocalGPU(double *gpu_cx, double *gpu_cy, double *gpu_cz,
                                  double *gpu_nx, double *gpu_ny, double *gpu_nz,
@@ -138,7 +147,7 @@ __global__ void SwapReciprocalGPU(double *gpu_x, double *gpu_y, double *gpu_z,
                                   double *gpu_sumRref,
                                   double *gpu_sumIref,
                                   double *gpu_prefactRef,
-                                  int insert,
+                                  const bool insert,
                                   double *gpu_energyRecipNew,
                                   int imageSize);
 

--- a/src/NoEwald.cpp
+++ b/src/NoEwald.cpp
@@ -22,20 +22,25 @@ void NoEwald::RecipInit(uint box, BoxDimensions const& boxAxes)
   return;
 }
 
-//calculate reciprocate term for a box
+//compute reciprocal term for a box with a new volume
 void NoEwald::BoxReciprocalSetup(uint box, XYZArray const& molCoords)
 {
   return;
 }
 
+//compute reciprocal term for a box when not testing a volume change
+void NoEwald::BoxReciprocalSums(uint box, XYZArray const& molCoords)
+{
+  return;
+}
 
-//calculate reciprocate term for a box
-double NoEwald::BoxReciprocal(uint box) const
+//calculate reciprocal term for a box
+double NoEwald::BoxReciprocal(uint box, bool isNewVolume) const
 {
   return 0.0;
 }
 
-//calculate reciprocate force term for a box with molCoords
+//calculate reciprocal force term for a box with molCoords
 void NoEwald::BoxForceReciprocal(XYZArray const& molCoords,
                                  XYZArray& atomForceRec, XYZArray& molForceRec,
                                  uint box)
@@ -43,14 +48,14 @@ void NoEwald::BoxForceReciprocal(XYZArray const& molCoords,
   return;
 }
 
-//calculate reciprocate force term for a box
+//calculate reciprocal force term for a box
 Virial NoEwald::VirialReciprocal(Virial& virial, uint box) const
 {
   return virial;
 }
 
 
-//calculate reciprocate term for displacement and rotation move
+//calculate reciprocal term for displacement and rotation move
 double NoEwald::MolReciprocal(XYZArray const& molCoords,
                               const uint molIndex, const uint box)
 {
@@ -58,7 +63,7 @@ double NoEwald::MolReciprocal(XYZArray const& molCoords,
 }
 
 
-//calculate reciprocate term for lambdaNew and Old with same coordinates
+//calculate reciprocal term for lambdaNew and Old with same coordinates
 double NoEwald::CFCMCRecip(XYZArray const& molCoords, const double lambdaOld,
                            const double lambdaNew, const uint molIndex,
                            const uint box)
@@ -81,7 +86,7 @@ double NoEwald::MolCorrection(uint molIndex, uint box) const
 }
 
 
-//calculate reciprocate term in destination box for swap move
+//calculate reciprocal term in destination box for swap move
 double NoEwald::SwapDestRecip(const cbmc::TrialMol &newMol,
                               const uint box,
                               const int molIndex)
@@ -90,7 +95,7 @@ double NoEwald::SwapDestRecip(const cbmc::TrialMol &newMol,
 }
 
 
-//calculate reciprocate term in source box for swap move
+//calculate reciprocal term in source box for swap move
 double NoEwald::SwapSourceRecip(const cbmc::TrialMol &oldMol,
                                 const uint box, const int molIndex)
 {
@@ -98,7 +103,7 @@ double NoEwald::SwapSourceRecip(const cbmc::TrialMol &oldMol,
 }
 
 
-//calculate reciprocate term for inserting some molecules (kindA) in destination
+//calculate reciprocal term for inserting some molecules (kindA) in destination
 // box and removing a molecule (kindB) from destination box
 double NoEwald::SwapRecip(const std::vector<cbmc::TrialMol> &newMol,
                           const std::vector<cbmc::TrialMol> &oldMol,
@@ -159,19 +164,19 @@ void NoEwald::ChangeRecip(Energy *energyDiff, Energy &dUdL_Coul,
 }
 
 
-//back up reciptocate value to Ref (will be called during initialization)
+//back up reciprocal value to Ref (will be called during initialization)
 void NoEwald::SetRecipRef(uint box)
 {
   return;
 }
 
-//update reciprocate values
+//update reciprocal values
 void NoEwald::UpdateRecip(uint box)
 {
   return;
 }
 
-//update the hx,y,z hsqr and prefact
+//update the kx, ky, kz, hsqr and prefact
 void NoEwald::UpdateRecipVec(uint box)
 {
   return;

--- a/src/NoEwald.h
+++ b/src/NoEwald.h
@@ -21,34 +21,37 @@ public:
 
   virtual void AllocMem();
 
-  //initiliazie term used for ewald calculation
+  //initialize term used for ewald calculation
   virtual void RecipInit(uint box, BoxDimensions const& boxAxes);
 
   //calculate self term for a box
   virtual double BoxSelf(uint box) const;
 
-  //setup reciprocate term for a box
+  //compute reciprocal term for a box with a new volume
   virtual void BoxReciprocalSetup(uint box, XYZArray const& molCoords);
 
-  //calculate reciprocate energy term for a box
-  virtual double BoxReciprocal(uint box) const;
+  //compute reciprocal term for a box when not testing a volume change
+  virtual void BoxReciprocalSums(uint box, XYZArray const& molCoords);
 
-  //calculate reciprocate force term for a box with molCoords
+  //calculate reciprocal energy term for a box
+  virtual double BoxReciprocal(uint box, bool isNewVolume) const;
+
+  //calculate reciprocal force term for a box with molCoords
   virtual void BoxForceReciprocal(XYZArray const& molCoords,
                                   XYZArray& atomForceRec, XYZArray& molForceRec,
                                   uint box);
 
-  //calculate reciprocate force term for a box
+  //calculate reciprocal force term for a box
   virtual Virial VirialReciprocal(Virial& virial, uint box) const;
 
   //calculate correction term for a molecule
   virtual double MolCorrection(uint molIndex, uint box)const;
 
-  //calculate reciprocate term for displacement and rotation move
+  //calculate reciprocal term for displacement and rotation move
   virtual double MolReciprocal(XYZArray const& molCoords, const uint molIndex,
                                const uint box);
 
-  //calculate reciprocate term for lambdaNew and Old with same coordinates
+  //calculate reciprocal term for lambdaNew and Old with same coordinates
   virtual double CFCMCRecip(XYZArray const& molCoords, const double lambdaOld,
                             const double lambdaNew, const uint molIndex,
                             const uint box);
@@ -63,15 +66,15 @@ public:
   virtual double SwapCorrection(const cbmc::TrialMol& trialMol,
                                 const uint molIndex) const;
 
-  //calculate reciprocate term in destination box for swap move
+  //calculate reciprocal term in destination box for swap move
   virtual double SwapDestRecip(const cbmc::TrialMol &newMol, const uint box,
                                const int molIndex);
 
-  //calculate reciprocate term in source box for swap move
+  //calculate reciprocal term in source box for swap move
   virtual double SwapSourceRecip(const cbmc::TrialMol &oldMol,
                                  const uint box, const int molIndex);
 
-  //calculate reciprocate term for inserting some molecules (kindA) in
+  //calculate reciprocal term for inserting some molecules (kindA) in
   //destination box and removing a molecule (kindB) from destination box
   virtual double SwapRecip(const std::vector<cbmc::TrialMol> &newMol,
                            const std::vector<cbmc::TrialMol> &oldMol,
@@ -79,7 +82,7 @@ public:
                            const std::vector<uint> molIndexold,
                            bool first_call);
 
-  //back up reciptocate value to Ref (will be called during initialization)
+  //back up reciprocal value to Ref (will be called during initialization)
   virtual void SetRecipRef(uint box);
 
   //It's called in free energy calculation to calculate the change in
@@ -103,10 +106,10 @@ public:
                            const uint iState, const uint molIndex,
                            const uint box) const;
 
-  //update reciprocate values
+  //update reciprocal values
   virtual void UpdateRecip(uint box);
 
-  //update the hx,y,z hsqr and prefact
+  //update the kx, ky, kz, hsqr and prefact
   virtual void UpdateRecipVec(uint box);
 
   //restore cosMol and sinMol

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -100,8 +100,8 @@ void Simulation::RunSimulation(void)
       system->cellList.GridAll(system->boxDimRef, system->coordinates, system->molLookup);
       if (staticValues->forcefield.ewald) {
         for(int box = 0; box < BOX_TOTAL; box++) {
-          system->calcEwald->BoxReciprocalSetup(box, system->coordinates);
-          system->potential.boxEnergy[box].recip = system->calcEwald->BoxReciprocal(box);
+          system->calcEwald->BoxReciprocalSums(box, system->coordinates, false);
+          system->potential.boxEnergy[box].recip = system->calcEwald->BoxReciprocal(box, false);
           system->calcEwald->UpdateRecip(box);
         }
       }

--- a/src/moves/IntraMoleculeExchange1.h
+++ b/src/moves/IntraMoleculeExchange1.h
@@ -583,7 +583,7 @@ inline void IntraMoleculeExchange1::Accept(const uint rejectState,
       sysPotRef.boxEnergy[sourceBox].correction += correctDiff;
 
       // Update reciprocal
-      calcEwald->BoxReciprocalSetup(sourceBox, coordCurrRef);
+      calcEwald->BoxReciprocalSums(sourceBox, coordCurrRef);
       calcEwald->UpdateRecip(sourceBox);
 
       // molA and molB already added to cellist

--- a/src/moves/MultiParticle.h
+++ b/src/moves/MultiParticle.h
@@ -158,7 +158,7 @@ inline uint MultiParticle::Prep(const double subDraw, const double movPerc)
   moveType = prng.randIntExc(mp::MPTOTALTYPES);
   SetMolInBox(bPick);
   if (moleculeIndex.size() == 0) {
-    std::cout << "Warning: Multi particle move can't move any molecules, Skipping...\n";
+    std::cout << "Warning: MultiParticle move can't move any molecules, Skipping...\n";
     state = mv::fail_state::NO_MOL_OF_KIND_IN_BOX;
     return state;
   }
@@ -288,16 +288,17 @@ inline void MultiParticle::CalcEn()
 
   //back up cached Fourier term
   calcEwald->backupMolCache();
+
   //setup reciprocal vectors for new positions
-  calcEwald->BoxReciprocalSetup(bPick, newMolsPos);
+  calcEwald->BoxReciprocalSums(bPick, newMolsPos);
 
   sysPotNew = sysPotRef;
   //calculate short range energy and force
   sysPotNew = calcEnRef.BoxForce(sysPotNew, newMolsPos, atomForceNew,
                                  molForceNew, boxDimRef, bPick);
-  //calculate long range of new electrostatic energy
-  sysPotNew.boxEnergy[bPick].recip = calcEwald->BoxReciprocal(bPick);
-  //Calculate long range of new electrostatic force
+  //calculate long range electrostatic energy for new positions
+  sysPotNew.boxEnergy[bPick].recip = calcEwald->BoxReciprocal(bPick, false);
+  //Calculate long range electrostatic force for new positions
   calcEwald->BoxForceReciprocal(newMolsPos, atomForceRecNew, molForceRecNew,
                                 bPick);
 
@@ -376,10 +377,10 @@ inline void MultiParticle::Accept(const uint rejectState, const uint step)
   // Here we compare the values of reference and trial and decide whether to
   // accept or reject the move
   double MPCoeff = GetCoeff();
-  double delta_real = sysPotNew.boxEnergy[bPick].real - sysPotRef.boxEnergy[bPick].real;
-  double delta_inter = sysPotNew.boxEnergy[bPick].inter - sysPotRef.boxEnergy[bPick].inter;
-  double delta_recip = sysPotNew.boxEnergy[bPick].recip - sysPotRef.boxEnergy[bPick].recip;
-  double uBoltz = exp(-BETA * (delta_real + delta_inter + delta_recip));
+  double delta_energy = sysPotNew.boxEnergy[bPick].real - sysPotRef.boxEnergy[bPick].real;
+  delta_energy += sysPotNew.boxEnergy[bPick].inter - sysPotRef.boxEnergy[bPick].inter;
+  delta_energy += sysPotNew.boxEnergy[bPick].recip - sysPotRef.boxEnergy[bPick].recip;
+  double uBoltz = exp(-BETA * delta_energy);
   double accept = MPCoeff * uBoltz;
   double pr = prng();
   bool result = (rejectState == mv::fail_state::NO_FAIL) && pr < accept;
@@ -430,11 +431,11 @@ inline XYZ MultiParticle::CalcRandomTransform(XYZ const &lb, double const max, u
   }
 
   if(num.Length() >= boxDimRef.axis.Min(bPick)) {
-    std::cout << "Trial Displacement exceeds half of the box length in Multiparticle move.\n";
+    std::cout << "Trial Displacement exceeds half of the box length in MultiParticle move.\n";
     std::cout << "Trial transform: " << num;
     exit(EXIT_FAILURE);
   } else if (!std::isfinite(num.Length())) {
-    std::cout << "Trial Displacement is not a finite number in Multiparticle move.\n";
+    std::cout << "Trial Displacement is not a finite number in MultiParticle move.\n";
     std::cout << "Trial transform: " << num;
     exit(EXIT_FAILURE);
   }

--- a/src/moves/VolumeTransfer.h
+++ b/src/moves/VolumeTransfer.h
@@ -159,34 +159,34 @@ inline void VolumeTransfer::CalcEn()
       //calculate new K vectors
       if(isOrth) {
         calcEwald->RecipInit(bPick[b], newDim);
-        //setup reciprocate terms
+        //setup reciprocal terms
         calcEwald->BoxReciprocalSetup(bPick[b], newMolsPos);
         sysPotNew = calcEnRef.BoxInter(sysPotNew, newMolsPos, newDim, bPick[b]);
       } else {
         calcEwald->RecipInit(bPick[b], newDimNonOrth);
-        //setup reciprocate terms
+        //setup reciprocal terms
         calcEwald->BoxReciprocalSetup(bPick[b], newMolsPos);
         sysPotNew = calcEnRef.BoxInter(sysPotNew, newMolsPos, newDimNonOrth,
                                        bPick[b]);
       }
-      //calculate reciprocate term of electrostatic interaction
-      sysPotNew.boxEnergy[bPick[b]].recip = calcEwald->BoxReciprocal(bPick[b]);
+      //calculate reciprocal term of electrostatic interaction
+      sysPotNew.boxEnergy[bPick[b]].recip = calcEwald->BoxReciprocal(bPick[b], true);
     }
   } else {
     //calculate new K vectors
     if(isOrth) {
       calcEwald->RecipInit(box, newDim);
-      //setup reciprocate terms
+      //setup reciprocal terms
       calcEwald->BoxReciprocalSetup(box, newMolsPos);
       sysPotNew = calcEnRef.BoxInter(sysPotNew, newMolsPos, newDim, box);
     } else {
       calcEwald->RecipInit(box, newDimNonOrth);
-      //setup reciprocate terms
+      //setup reciprocal terms
       calcEwald->BoxReciprocalSetup(box, newMolsPos);
       sysPotNew = calcEnRef.BoxInter(sysPotNew, newMolsPos, newDimNonOrth, box);
     }
-    //calculate reciprocate term of electrostatic interaction
-    sysPotNew.boxEnergy[box].recip = calcEwald->BoxReciprocal(box);
+    //calculate reciprocal term of electrostatic interaction
+    sysPotNew.boxEnergy[box].recip = calcEwald->BoxReciprocal(box, true);
   }
 
   sysPotNew.Total();


### PR DESCRIPTION
Many of the changes are related to functions used only by MultiParticle, such as BoxForceReciprocal, but since the changes are relatively extensive, it would be better to be reviewed before being merged into the development branch.

I validated the code by creating a simpler, but less efficient and less elegant, patch to just rebuild the k-vectors for the current box dimensions when a MP move starts. In the tests I ran, the patched GPU and CPU codes are matching each other and are matching with this simpler patch.

I did not test MEMC, because MEMC+MP is currently not producing correct results. This needs to be fixed and the BoxReciprocalSums function can probably be removed. But this will be verified when MEMC is working with MP.

I added and modified some comments in the code. I think that improves the code base in the long run, but I realize that it also makes it harder to review this patch.