### PR TITLE
Probabilities and Coefficients are calculated using only swappable molecules for molecule transfer and MEMC.

### DIFF
--- a/src/MoleculeLookup.cpp
+++ b/src/MoleculeLookup.cpp
@@ -22,12 +22,18 @@ void MoleculeLookup::Init(const Molecules& mols,
 
   //+1 to store end value
   boxAndKindStart = new uint[numKinds * BOX_TOTAL + 1];
+  boxAndKindSwappableCounts = new uint[numKinds * BOX_TOTAL];
+
   boxAndKindStartCount = numKinds * BOX_TOTAL + 1;
 
   // vector[box][kind] = list of mol indices for kind in box
   std::vector<std::vector<std::vector<uint> > > indexVector;
   indexVector.resize(BOX_TOTAL);
   fixedAtom.resize(mols.count);
+
+  for (int i = 0; i < numKinds * BOX_TOTAL; i++){
+    boxAndKindSwappableCounts[i] = 0;
+  }
 
 
   for (uint b = 0; b < BOX_TOTAL; ++b) {
@@ -49,6 +55,8 @@ void MoleculeLookup::Init(const Molecules& mols,
       if(std::find(canMoveKind.begin(), canMoveKind.end(), kind) ==
           canMoveKind.end())
         canMoveKind.push_back(kind);
+
+      boxAndKindSwappableCounts[box * numKinds + kind]++;
 
     } else if(fixedAtom[m] == 2) {
       if(std::find(canMoveKind.begin(), canMoveKind.end(), kind) ==
@@ -129,6 +137,10 @@ void MoleculeLookup::Shift(const uint index, const uint currentBox,
   uint oldIndex = index;
   uint newIndex;
   uint section = currentBox * numKinds + kind;
+
+  boxAndKindSwappableCounts[section]--;
+  boxAndKindSwappableCounts[intoBox * numKinds + kind]++;
+
   if(currentBox >= intoBox) {
     while (section != intoBox * numKinds + kind) {
       newIndex = boxAndKindStart[section]++;

--- a/src/MoleculeLookup.h
+++ b/src/MoleculeLookup.h
@@ -33,6 +33,7 @@ public:
   {
     delete[] molLookup;
     delete[] boxAndKindStart;
+    delete[] boxAndKindSwappableCounts;
   }
 
   //Initialize this object to be consistent with Molecules mols

--- a/src/MoleculeLookup.h
+++ b/src/MoleculeLookup.h
@@ -66,6 +66,8 @@ public:
   //Returns number of given kind in given box
   uint NumKindInBox(const uint kind, const uint box) const;
 
+  uint NumKindInBoxSwappable(const uint kind, const uint box) const;
+
   //!Returns total number of molecules in a given box
   uint NumInBox(const uint box) const;
 
@@ -125,6 +127,7 @@ private:
   //index [BOX_TOTAL * kind + box + 1] is the element after the end
   //of that kind/box
   uint* boxAndKindStart;
+  uint* boxAndKindSwappableCounts;
   uint boxAndKindStartCount;
   uint numKinds;
   std::vector <uint> fixedAtom;
@@ -141,7 +144,10 @@ inline uint MoleculeLookup::NumKindInBox(const uint kind, const uint box) const
          boxAndKindStart[box * numKinds + kind];
 }
 
-
+inline uint MoleculeLookup::NumKindInBoxSwappable(const uint kind, const uint box) const
+{
+  return boxAndKindSwappableCounts[box * numKinds + kind];
+}
 
 class MoleculeLookup::box_iterator
 {

--- a/src/moves/MoleculeExchange1.h
+++ b/src/moves/MoleculeExchange1.h
@@ -252,7 +252,7 @@ inline void MoleculeExchange1::SetBox()
     for(uint b = 0; b < BOX_TOTAL; b++) {
       density = 0.0;
       for(uint k = 0; k < molLookRef.GetNumKind(); k++) {
-        density += molLookRef.NumKindInBox(k, b) * boxDimRef.volInv[b] *
+        density += molLookRef.NumKindInBoxSwappable(k, b) * boxDimRef.volInv[b] *
                    molRef.kinds[k].molMass;
       }
       if(density > maxDens) {

--- a/src/moves/MoleculeExchange1.h
+++ b/src/moves/MoleculeExchange1.h
@@ -252,7 +252,7 @@ inline void MoleculeExchange1::SetBox()
     for(uint b = 0; b < BOX_TOTAL; b++) {
       density = 0.0;
       for(uint k = 0; k < molLookRef.GetNumKind(); k++) {
-        density += molLookRef.NumKindInBoxSwappable(k, b) * boxDimRef.volInv[b] *
+        density += molLookRef.NumKindInBox(k, b) * boxDimRef.volInv[b] *
                    molRef.kinds[k].molMass;
       }
       if(density > maxDens) {

--- a/src/moves/MoleculeExchange1.h
+++ b/src/moves/MoleculeExchange1.h
@@ -550,7 +550,7 @@ inline void MoleculeExchange1::CalcTc()
     for (uint b = 0; b < BOX_TOTAL; ++b) {
       uint* kCount = new uint[molRef.kindsCount];
       for (uint k = 0; k < molRef.kindsCount; ++k) {
-        kCount[k] = molLookRef.NumKindInBoxSwappable(k, b);
+        kCount[k] = molLookRef.NumKindInBox(k, b);
       }
 
       if (b == sourceBox) {

--- a/src/moves/MoleculeExchange1.h
+++ b/src/moves/MoleculeExchange1.h
@@ -414,10 +414,10 @@ inline uint MoleculeExchange1::Prep(const double subDraw, const double movPerc)
 {
   uint state = GetBoxPairAndMol(subDraw, movPerc);
   if(state == mv::fail_state::NO_FAIL) {
-    numTypeASource = (double)(molLookRef.NumKindInBox(kindIndexA[0], sourceBox));
-    numTypeADest = (double)(molLookRef.NumKindInBox(kindIndexA[0], destBox));
-    numTypeBSource = (double)(molLookRef.NumKindInBox(kindIndexB[0], sourceBox));
-    numTypeBDest = (double)(molLookRef.NumKindInBox(kindIndexB[0], destBox));
+    numTypeASource = (double)(molLookRef.NumKindInBoxSwappable(kindIndexA[0], sourceBox));
+    numTypeADest = (double)(molLookRef.NumKindInBoxSwappable(kindIndexA[0], destBox));
+    numTypeBSource = (double)(molLookRef.NumKindInBoxSwappable(kindIndexB[0], sourceBox));
+    numTypeBDest = (double)(molLookRef.NumKindInBoxSwappable(kindIndexB[0], destBox));
 
     //transferring type A from source to dest
     for(uint n = 0; n < numInCavA; n++) {
@@ -550,7 +550,7 @@ inline void MoleculeExchange1::CalcTc()
     for (uint b = 0; b < BOX_TOTAL; ++b) {
       uint* kCount = new uint[molRef.kindsCount];
       for (uint k = 0; k < molRef.kindsCount; ++k) {
-        kCount[k] = molLookRef.NumKindInBox(k, b);
+        kCount[k] = molLookRef.NumKindInBoxSwappable(k, b);
       }
 
       if (b == sourceBox) {

--- a/src/moves/MoleculeExchange2.h
+++ b/src/moves/MoleculeExchange2.h
@@ -229,10 +229,10 @@ inline uint MoleculeExchange2::Prep(const double subDraw, const double movPerc)
 {
   uint state = GetBoxPairAndMol(subDraw, movPerc);
   if(state == mv::fail_state::NO_FAIL) {
-    numTypeASource = (double)(molLookRef.NumKindInBox(kindIndexA[0], sourceBox));
-    numTypeADest = (double)(molLookRef.NumKindInBox(kindIndexA[0], destBox));
-    numTypeBSource = (double)(molLookRef.NumKindInBox(kindIndexB[0], sourceBox));
-    numTypeBDest = (double)(molLookRef.NumKindInBox(kindIndexB[0], destBox));
+    numTypeASource = (double)(molLookRef.NumKindInBoxSwappable(kindIndexA[0], sourceBox));
+    numTypeADest = (double)(molLookRef.NumKindInBoxSwappable(kindIndexA[0], destBox));
+    numTypeBSource = (double)(molLookRef.NumKindInBoxSwappable(kindIndexB[0], sourceBox));
+    numTypeBDest = (double)(molLookRef.NumKindInBoxSwappable(kindIndexB[0], destBox));
     //transferring type A from source to dest
     for(uint n = 0; n < numInCavA; n++) {
       newMolA.push_back(cbmc::TrialMol(molRef.kinds[kindIndexA[n]], boxDimRef,

--- a/src/moves/MoleculeExchange3.h
+++ b/src/moves/MoleculeExchange3.h
@@ -186,10 +186,10 @@ inline uint MoleculeExchange3::Prep(const double subDraw, const double movPerc)
 {
   uint state = GetBoxPairAndMol(subDraw, movPerc);
   if(state == mv::fail_state::NO_FAIL) {
-    numTypeASource = (double)(molLookRef.NumKindInBox(kindIndexA[0], sourceBox));
-    numTypeADest = (double)(molLookRef.NumKindInBox(kindIndexA[0], destBox));
-    numTypeBSource = (double)(molLookRef.NumKindInBox(kindIndexB[0], sourceBox));
-    numTypeBDest = (double)(molLookRef.NumKindInBox(kindIndexB[0], destBox));
+    numTypeASource = (double)(molLookRef.NumKindInBoxSwappable(kindIndexA[0], sourceBox));
+    numTypeADest = (double)(molLookRef.NumKindInBoxSwappable(kindIndexA[0], destBox));
+    numTypeBSource = (double)(molLookRef.NumKindInBoxSwappable(kindIndexB[0], sourceBox));
+    numTypeBDest = (double)(molLookRef.NumKindInBoxSwappable(kindIndexB[0], destBox));
     //transferring type A from source to dest
     for(uint n = 0; n < numInCavA; n++) {
       newMolA.push_back(cbmc::TrialMol(molRef.kinds[kindIndexA[n]], boxDimRef,

--- a/src/moves/MoleculeTransfer.h
+++ b/src/moves/MoleculeTransfer.h
@@ -137,28 +137,28 @@ inline void MoleculeTransfer::CalcEn()
 inline double MoleculeTransfer::GetCoeff() const
 {
 #if ENSEMBLE == GEMC
-  return (double)(molLookRef.NumKindInBox(kindIndex, sourceBox)) /
-         (double)(molLookRef.NumKindInBox(kindIndex, destBox) + 1) *
+  return (double)(molLookRef.NumKindInBoxSwappable(kindIndex, sourceBox)) /
+         (double)(molLookRef.NumKindInBoxSwappable(kindIndex, destBox) + 1) *
          boxDimRef.volume[destBox] * boxDimRef.volInv[sourceBox];
 #elif ENSEMBLE == GCMC
   if (sourceBox == mv::BOX0) { //Delete case
     if(ffRef.isFugacity) {
-      return (double)(molLookRef.NumKindInBox(kindIndex, sourceBox)) *
+      return (double)(molLookRef.NumKindInBoxSwappable(kindIndex, sourceBox)) *
              boxDimRef.volInv[sourceBox] /
              (BETA * molRef.kinds[kindIndex].chemPot);
     } else {
-      return (double)(molLookRef.NumKindInBox(kindIndex, sourceBox)) *
+      return (double)(molLookRef.NumKindInBoxSwappable(kindIndex, sourceBox)) *
              boxDimRef.volInv[sourceBox] *
              exp(-BETA * molRef.kinds[kindIndex].chemPot);
     }
   } else { //Insertion case
     if(ffRef.isFugacity) {
       return boxDimRef.volume[destBox] /
-             (double)(molLookRef.NumKindInBox(kindIndex, destBox) + 1) *
+             (double)(molLookRef.NumKindInBoxSwappable(kindIndex, destBox) + 1) *
              (BETA * molRef.kinds[kindIndex].chemPot);
     } else {
       return boxDimRef.volume[destBox] /
-             (double)(molLookRef.NumKindInBox(kindIndex, destBox) + 1) *
+             (double)(molLookRef.NumKindInBoxSwappable(kindIndex, destBox) + 1) *
              exp(BETA * molRef.kinds[kindIndex].chemPot);
     }
   }


### PR DESCRIPTION
The ensembles which vary in particle number should use the number of eligible molecules in each box for calculating probabilities related to transferring molecules.  We now calculate this value at the beginning of a simulation and modify it (increment into box and decrement source box) when transferring a molecule.

Before 

![output](https://user-images.githubusercontent.com/39970712/103406107-89a48380-4b27-11eb-8cc6-e8b8610d4561.png)

After

![output](https://user-images.githubusercontent.com/39970712/103406118-91642800-4b27-11eb-95a5-12c0a387f0db.png)
