### PR TITLE
Fix to #issue312

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(src/GPU)
 
 # Enable google test
 # for now we will disable testing for intel compiler
-if(NOT "${CMAKE_CXX_COMPILER_ID}" STRNEQUAL "Intel")
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   enable_testing()
   include(test/GoogleTest.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,11 @@ include_directories(src/moves)
 include_directories(src/GPU)
 
 # Enable google test
-enable_testing()
-include(test/GoogleTest.cmake)
+# for now we will disable testing for intel compiler
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STRNEQUAL "Intel")
+  enable_testing()
+  include(test/GoogleTest.cmake)
+endif()
 
 #Out-of-source build
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/metamake.sh
+++ b/metamake.sh
@@ -75,9 +75,15 @@ fi
 
 mkdir -p bin
 cd bin
-ICC_PATH="$(which icc 2> /dev/null)"
-ICPC_PATH="$(which icpc 2> /dev/null)"
-export CC=${ICC_PATH}
-export CXX=${ICPC_PATH}
+COMPILER_C_PATH="$(which icc 2> /dev/null)"
+COMPILER_CXX_PATH="$(which icpc 2> /dev/null)"
+# if intel was not available, link to gcc
+if [ -z "$COMPILER_C_PATH" ]
+then
+  COMPILER_C_PATH="$(which gcc 2> /dev/null)"
+  COMPILER_CXX_PATH="$(which g++ 2> /dev/null)"
+fi
+export CC=${COMPILER_C_PATH}
+export CXX=${COMPILER_CXX_PATH}
 cmake ..
 make -j8


### PR DESCRIPTION
This patch will do the following:
1. Disable `googletest` for intel compiler
2. Manually set  gcc compiler if intel compiler was not found.