### PR TITLE
Norm move perc

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -32,6 +32,60 @@ double stringtod(const std::string& s)
   return i;
 }
 
+void ConfigSetup::NormalizeMovePercentages(config_setup::MovePercents & moves, double & sum){
+    std::cout << "Move Frequencies normalized to 1.0" << std::endl;
+  #if ENSEMBLE == GEMC
+    std::cout << "Displacement : " << (moves.displace /= sum) << std::endl;
+    std::cout << "Rotation : " << (moves.rotate /= sum) << std::endl;
+    std::cout << "Transfer : " << (moves.transfer /= sum) << std::endl;
+    std::cout << "Intraswap : " << (moves.intraSwap  /= sum) << std::endl;
+    std::cout << "Volume : " << (moves.volume  /= sum) << std::endl;
+    std::cout << "Regrowth : " << (moves.regrowth /= sum) << std::endl;
+    std::cout << "MEMC : " << (moves.memc  /= sum) << std::endl;
+    std::cout << "intra-MEMC : " << (moves.intraMemc  /= sum) << std::endl;
+    std::cout << "Crankshaft : " << (moves.crankShaft /= sum) << std::endl;
+    std::cout << "Multiparticle : " << (moves.multiParticle  /= sum) << std::endl;
+    std::cout << "CFCMC : " << (moves.cfcmc /= sum) << std::endl;
+  #elif ENSEMBLE == NPT
+    std::cout << "Displacement : " << (moves.displace /= sum) << std::endl;
+    std::cout << "Rotation : " << (moves.rotate /= sum) << std::endl;
+    //std::cout << "Transfer : " << (moves.transfer /= sum) << std::endl;
+    std::cout << "Intraswap : " << (moves.intraSwap  /= sum) << std::endl;
+    std::cout << "Volume : " << (moves.volume  /= sum) << std::endl;
+    std::cout << "Regrowth : " << (moves.regrowth /= sum) << std::endl;
+    //std::cout << "MEMC : " << (moves.memc  /= sum) << std::endl;
+    std::cout << "intra-MEMC : " << (moves.intraMemc  /= sum) << std::endl;
+    std::cout << "Crankshaft : " << (moves.crankShaft /= sum) << std::endl;
+    std::cout << "Multiparticle : " << (moves.multiParticle  /= sum) << std::endl;
+    //std::cout << "CFCMC : " << (moves.cfcmc /= sum) << std::endl;
+  #elif ENSEMBLE == GCMC
+    std::cout << "Displacement : " << (moves.displace /= sum) << std::endl;
+    std::cout << "Rotation : " << (moves.rotate /= sum) << std::endl;
+    std::cout << "Transfer : " << (moves.transfer /= sum) << std::endl;
+    std::cout << "Intraswap : " << (moves.intraSwap  /= sum) << std::endl;
+    //std::cout << "Volume : " << (moves.volume  /= sum) << std::endl;
+    std::cout << "Regrowth : " << (moves.regrowth /= sum) << std::endl;
+    std::cout << "MEMC : " << (moves.memc  /= sum) << std::endl;
+    std::cout << "intra-MEMC : " << (moves.intraMemc  /= sum) << std::endl;
+    std::cout << "Crankshaft : " << (moves.crankShaft /= sum) << std::endl;
+    std::cout << "Multiparticle : " << (moves.multiParticle  /= sum) << std::endl;
+    std::cout << "CFCMC : " << (moves.cfcmc /= sum) << std::endl;
+  #else
+    std::cout << "Displacement : " << (moves.displace /= sum) << std::endl;
+    std::cout << "Rotation : " << (moves.rotate /= sum) << std::endl;
+    //std::cout << "Transfer : " << (moves.transfer /= sum) << std::endl;
+    std::cout << "Intraswap : " << (moves.intraSwap  /= sum) << std::endl;
+    //std::cout << "Volume : " << (moves.volume  /= sum) << std::endl;
+    std::cout << "Regrowth : " << (moves.regrowth /= sum) << std::endl;
+    //std::cout << "MEMC : " << (moves.memc  /= sum) << std::endl;
+    std::cout << "intra-MEMC : " << (moves.intraMemc  /= sum) << std::endl;
+    std::cout << "Crankshaft : " << (moves.crankShaft /= sum) << std::endl;
+    std::cout << "Multiparticle : " << (moves.multiParticle  /= sum) << std::endl;
+    //std::cout << "CFCMC : " << (moves.cfcmc /= sum) << std::endl;
+  #endif
+}
+
+
 
 ConfigSetup::ConfigSetup(void)
 {
@@ -1506,62 +1560,50 @@ void ConfigSetup::verifyInputs(void)
     exit(EXIT_FAILURE);
   }
   if(sys.moves.displace == DBL_MAX) {
-    std::cout << "Error: Displacement move frequency is not specified!\n";
-    exit(EXIT_FAILURE);
+    std::cout << "Warning: Displacement move frequency is not specified!\n";
   }
-#if ENSEMBLE == NPT
+#if ENSEMBLE == NPT || ENSEMBLE == GEMC
   if(sys.moves.volume == DBL_MAX) {
-    std::cout << "Error: Volume move frequency is not specified!" << std::endl;
-    exit(EXIT_FAILURE);
+    std::cout << "Warning: Volume move frequency is not specified!" << std::endl;
   }
 #endif
+double sum;
 #if ENSEMBLE == GEMC
-  if(sys.moves.volume == DBL_MAX) {
-    std::cout << "Error: Volume move frequency is not specified!" << std::endl;
-    exit(EXIT_FAILURE);
-  }
   if(sys.moves.transfer == DBL_MAX) {
-    std::cout << "Error: Molecule swap move frequency is not specified!\n";
-    exit(EXIT_FAILURE);
+    std::cout << "Warning: Molecule swap move frequency is not specified!\n";
   }
-  if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.transfer +
+  if(sum = std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.transfer +
               sys.moves.intraSwap + sys.moves.volume + sys.moves.regrowth +
               sys.moves.memc + sys.moves.intraMemc + sys.moves.crankShaft +
               sys.moves.multiParticle + sys.moves.cfcmc - 1.0) > 0.001) {
     std::cout << "Error: Sum of move frequencies is not equal to one!\n";
-    exit(EXIT_FAILURE);
+    NormalizeMovePercentages(sys.moves, sum);
   }
 #elif ENSEMBLE == NPT
-  if(sys.moves.volume == DBL_MAX) {
-    std::cout << "Error: Volume move frequency is not specified!" << std::endl;
-    exit(EXIT_FAILURE);
-  }
-
-  if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
+  if(sum = std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
               sys.moves.volume + sys.moves.regrowth + sys.moves.intraMemc +
               sys.moves.crankShaft + sys.moves.multiParticle - 1.0) > 0.001) {
     std::cout << "Error: Sum of move frequencies is not equal to one!\n";
-    exit(EXIT_FAILURE);
+    NormalizeMovePercentages(sys.moves, sum);
   }
 
 #elif ENSEMBLE == GCMC
   if(sys.moves.transfer == DBL_MAX) {
-    std::cout << "Error: Molecule swap move frequency is not specified!\n";
-    exit(EXIT_FAILURE);
+    std::cout << "Warning: Molecule swap move frequency is not specified!\n";
   }
-  if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
+  if(sum = std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
               sys.moves.transfer + sys.moves.regrowth + sys.moves.memc +
               sys.moves.intraMemc + sys.moves.crankShaft +
               sys.moves.multiParticle + sys.moves.cfcmc - 1.0) > 0.001) {
     std::cout << "Error: Sum of move frequencies is not equal to one!!\n";
-    exit(EXIT_FAILURE);
+    NormalizeMovePercentages(sys.moves, sum);
   }
 #else
-  if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
+  if(sum = std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
               sys.moves.regrowth + sys.moves.intraMemc + sys.moves.crankShaft +
               sys.moves.multiParticle - 1.0) > 0.001) {
     std::cout << "Error: Sum of move frequencies is not equal to one!!\n";
-    exit(EXIT_FAILURE);
+    NormalizeMovePercentages(sys.moves, sum);
   }
 #endif
 

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -33,6 +33,15 @@ double stringtod(const std::string& s)
 }
 
 void ConfigSetup::NormalizeMovePercentages(config_setup::MovePercents & moves, double & sum){
+  if (sum == 0.0){
+    std::cout << "Error: Sum is zero, so normalize would divide by zero.\n" <<
+    "Please provide non-zero frequencies to eligible moves in your ensemble." << 
+    "Ineligible moves for NVT : Transfer, Volume, MEMC, CFCMC" << std::endl << 
+    "Ineligible moves for NPT : Transfer, MEMC, CFCMC" << std::endl << 
+    "Ineligible moves for GCMC : Volume" << std::endl << 
+    "Ineligible moves for GEMC : None" << std::endl;
+    exit(EXIT_FAILURE); 
+  }
     std::cout << "Move Frequencies normalized to 1.0" << std::endl;
   #if ENSEMBLE == GEMC
     std::cout << "Displacement : " << (moves.displace /= sum) << std::endl;

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -409,6 +409,7 @@ public:
   config_setup::SystemVals sys;
   ConfigSetup(void);
   void Init(const char *fileName, MultiSim const*const& multisim);
+  void NormalizeMovePercentages(config_setup::MovePercents & moves, double & sum);
 private:
   void fillDefaults(void);
   bool checkBool(std::string str);

--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -62,7 +62,7 @@ void BriefDihKinds(MolKind& kind, const FFSetup& ffData);
 int ReadPSF(const char* psfFilename, MoleculeVariables & molVars, MolMap& kindMap, SizeMap& sizeMap, pdb_setup::Atoms& pdbData, MolMap * kindMapFromBox1 = NULL, SizeMap * sizeMapFromBox1 = NULL);
 //adds atoms and molecule data in psf to kindMap
 //pre: stream is at !NATOMS   post: stream is at end of atom section
-int ReadPSFAtoms(FILE *, unsigned int nAtoms, std::vector<mol_setup::Atom> & allAtoms);
+int ReadPSFAtoms(FILE *, uint nAtoms, std::vector<mol_setup::Atom> & allAtoms);
 //adds bonds in psf to kindMap
 //pre: stream is before !BONDS   post: stream is in bond section just after
 //the first appearance of the last molecule
@@ -831,7 +831,7 @@ int ReadPSF(const char* psfFilename, MoleculeVariables & molVars, MolMap& kindMa
     return errors::READ_ERROR;
   }
   char input[512];
-  unsigned int nAtoms;
+  uint nAtoms;
   //find atom header+count
   do {
     check = fgets(input, 511, psf);
@@ -961,7 +961,7 @@ int ReadPSF(const char* psfFilename, MoleculeVariables & molVars, MolMap& kindMa
 
 //adds atoms and molecule data in psf to kindMap
 //pre: stream is at !NATOMS   post: stream is at end of atom section
-int ReadPSFAtoms(FILE *psf, unsigned int nAtoms, std::vector<mol_setup::Atom> & allAtoms)
+int ReadPSFAtoms(FILE *psf, uint nAtoms, std::vector<mol_setup::Atom> & allAtoms)
 {
   char input[512];
   unsigned int atomID = 0;


### PR DESCRIPTION
This pull request allows for the user to enter 100% swap moves without an error stating he needs to give a value for displacement moves.  Also, if the move percents don't add up to 100%, the percentages are normalized to 100%, and a warning is printed telling the user that this is happening.