### PR TITLE
Unique id in segment

### DIFF
--- a/CMake/FileLists.cmake
+++ b/CMake/FileLists.cmake
@@ -184,6 +184,7 @@ set(headers
    src/moves/VolumeTransfer.h)
 
 set(libHeaders
+   lib/AlphaNum.h
    lib/BasicTypes.h
    lib/BitLib.h
    lib/Endian.h
@@ -197,6 +198,7 @@ set(libHeaders
    lib/FloydWarshallCycle.h)
 
 set(libSources
+    lib/AlphaNum.cpp
     lib/CircuitFinder.cpp
     lib/FloydWarshallCycle.cpp)
 

--- a/lib/AlphaNum.cpp
+++ b/lib/AlphaNum.cpp
@@ -4,6 +4,10 @@ AlphaNum::AlphaNum(){}
 
 /* Alpha numberic A, B, ... Z, AA, AB, ... AZ, */
 /* Index from 0 to A */
+// return true if s1 comes before s2
+
+// compare character case-insensitive
+
 
 std::string AlphaNum::uint2String(uint stringSuffix){
 
@@ -28,3 +32,4 @@ std::string AlphaNum::uint2String(uint stringSuffix){
 
     return forwards.assign(backwards.rbegin(), backwards.rend());
 }
+

--- a/lib/AlphaNum.cpp
+++ b/lib/AlphaNum.cpp
@@ -1,0 +1,30 @@
+#include "AlphaNum.h"
+
+AlphaNum::AlphaNum(){}
+
+/* Alpha numberic A, B, ... Z, AA, AB, ... AZ, */
+/* Index from 0 to A */
+
+std::string AlphaNum::uint2String(uint stringSuffix){
+
+    std::stringstream ss;
+    char charSuffix;
+    int intermediate = stringSuffix;
+    int remainder = 0;
+    do {
+        charSuffix = 'A';
+        remainder = intermediate % 26;
+        /* Increment Char A until reach suffix or 27 which will be Z. */
+        for (int j = 0; j < remainder; j++){
+            charSuffix++;
+        }
+        ss << charSuffix;
+        intermediate /= 26;
+        intermediate--;
+    } while (intermediate >= 0);
+
+    std::string backwards = ss.str();
+    std::string forwards;
+
+    return forwards.assign(backwards.rbegin(), backwards.rend());
+}

--- a/lib/AlphaNum.h
+++ b/lib/AlphaNum.h
@@ -1,0 +1,18 @@
+/*******************************************************************************
+GPU OPTIMIZED MONTE CARLO (GOMC) 2.70
+Copyright (C) 2018  GOMC Group
+A copy of the GNU General Public License can be found in the COPYRIGHT.txt
+along with this program, also can be found at <http://www.gnu.org/licenses/>.
+********************************************************************************/
+#pragma once
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <sstream>      // std::stringstream
+
+class AlphaNum
+{
+    public:
+        AlphaNum();
+        std::string uint2String(uint stringSuffix);
+};

--- a/lib/AlphaNum.h
+++ b/lib/AlphaNum.h
@@ -9,10 +9,33 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cassert>
 #include <sstream>      // std::stringstream
+#include <algorithm>
+#include <string>
+#include <cctype>
+
+struct icompare_char {
+  bool operator()(char c1, char c2) {
+    return std::toupper(c1) < std::toupper(c2);
+  }
+};
+
+struct compare {
+  bool operator()(const std::pair<std::string, int>& lhs, const std::pair<std::string, int>& rhs) {
+    if (lhs.first.length() > rhs.first.length())
+      return false;
+    if (lhs.first.length() < rhs.first.length())
+      return true;
+    return std::lexicographical_compare(lhs.first.begin(), lhs.first.end(),
+                                        rhs.first.begin(), rhs.first.end(),
+                                        icompare_char());
+  }
+};
 
 class AlphaNum
 {
     public:
         AlphaNum();
         std::string uint2String(uint stringSuffix);
+        struct icompare_char;
+        struct compare;
 };

--- a/lib/StrStrmLib.h
+++ b/lib/StrStrmLib.h
@@ -95,14 +95,14 @@ inline char *& FromStr(char *& c, std::string const& str)
 
 
 struct Converter {
-  std::stringstream strm;
+  std::stringstream strm;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
 
   Converter()
   {
     AutoFmt();
-  }
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    }
 
-  //No width or precision set, by default.
+  //No width or precision set, by default.                                                        
   Converter & AutoFmt()
   {
     Align(align::RIGHT).Fixed();

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -261,6 +261,13 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
         in.files.psf.name[boxnum] = line[2];
       }
       in.files.psf.defined[boxnum] = true;
+    } else if(CheckString(line[0], "ReferenceStructure")) {
+      if (multisim != NULL) {
+        in.files.referenceStructure.name[0] = multisim->replicaInputDirectoryPath + line[1];
+      } else {
+        in.files.referenceStructure.name[0] = line[1];
+      }
+      in.files.referenceStructure.defined[0] = true;
     } else if(CheckString(line[0], "binCoordinates")) {
       uint boxnum = stringtoi(line[1]);
       if(boxnum >= BOX_TOTAL) {

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -24,6 +24,7 @@ ConfigSetup::ConfigSetup(void)
   in.restart.restartFromCheckpoint = false;
   in.restart.restartFromBinaryFile = false;
   in.restart.restartFromXSCFile = false;
+  in.restart.hybrid = false;
   in.prng.seed = UINT_MAX;
   in.prngParallelTempering.seed = UINT_MAX;
   sys.elect.readEwald = false;
@@ -297,6 +298,8 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
       }
       in.files.checkpoint.defined[0] = true;
       in.restart.restartFromCheckpoint = true;
+    } else if(CheckString(line[0], "Hybrid")) {
+      in.restart.hybrid = true;
     }
 #if ENSEMBLE == GEMC
     else if(CheckString(line[0], "GEMC")) {

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -26,6 +26,11 @@ ConfigSetup::ConfigSetup(void)
   in.restart.restartFromXSCFile = false;
   in.prng.seed = UINT_MAX;
   in.prngParallelTempering.seed = UINT_MAX;
+  /* Hybrid MC-MD Cycle Restarts */
+  in.restart.sortBySegmentLabels = false;
+  out.sortBySegmentLabels.enable = false;
+  /* Hybrid MC-MD Cycle Restarts */
+  in.restart.generateSegmentLabels = false;
   sys.elect.readEwald = false;
   sys.elect.readElect = false;
   sys.elect.readCache = false;
@@ -129,6 +134,7 @@ ConfigSetup::ConfigSetup(void)
 #endif
   out.statistics.vars.density.block = false;
   out.statistics.vars.density.fluct = false;
+
 }
 
 int ConfigSetup::stringtoi(const std::string& s)
@@ -261,13 +267,12 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
         in.files.psf.name[boxnum] = line[2];
       }
       in.files.psf.defined[boxnum] = true;
-    } else if(CheckString(line[0], "ReferenceStructure")) {
-      if (multisim != NULL) {
-        in.files.referenceStructure.name[0] = multisim->replicaInputDirectoryPath + line[1];
-      } else {
-        in.files.referenceStructure.name[0] = line[1];
-      }
-      in.files.referenceStructure.defined[0] = true;
+    /* Reference Order of Atoms In Trajectory File For Hybrid MC-MD */
+    } else if(CheckString(line[0], "SortBySegment")) {
+        in.restart.sortBySegmentLabels = checkBool(line[1]);
+        out.sortBySegmentLabels.enable = in.restart.sortBySegmentLabels;
+    } else if(CheckString(line[0], "GenerateSegmentLabels")) {
+        in.restart.generateSegmentLabels = checkBool(line[1]);
     } else if(CheckString(line[0], "binCoordinates")) {
       uint boxnum = stringtoi(line[1]);
       if(boxnum >= BOX_TOTAL) {

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -26,11 +26,6 @@ ConfigSetup::ConfigSetup(void)
   in.restart.restartFromXSCFile = false;
   in.prng.seed = UINT_MAX;
   in.prngParallelTempering.seed = UINT_MAX;
-  /* Hybrid MC-MD Cycle Restarts */
-  in.restart.sortBySegmentLabels = false;
-  out.sortBySegmentLabels.enable = false;
-  /* Hybrid MC-MD Cycle Restarts */
-  in.restart.generateSegmentLabels = false;
   sys.elect.readEwald = false;
   sys.elect.readElect = false;
   sys.elect.readCache = false;
@@ -268,11 +263,6 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
       }
       in.files.psf.defined[boxnum] = true;
     /* Reference Order of Atoms In Trajectory File For Hybrid MC-MD */
-    } else if(CheckString(line[0], "SortBySegment")) {
-        in.restart.sortBySegmentLabels = checkBool(line[1]);
-        out.sortBySegmentLabels.enable = in.restart.sortBySegmentLabels;
-    } else if(CheckString(line[0], "GenerateSegmentLabels")) {
-        in.restart.generateSegmentLabels = checkBool(line[1]);
     } else if(CheckString(line[0], "binCoordinates")) {
       uint boxnum = stringtoi(line[1]);
       if(boxnum >= BOX_TOTAL) {

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -876,7 +876,7 @@ struct Statistics {
 struct Output {
   SysState state, restart, state_dcd, restart_dcd;
   Statistics statistics;
-  EventSettings console, checkpoint, sortBySegmentLabels;
+  EventSettings console, checkpoint;
 };
 
 }

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -77,6 +77,8 @@ struct RestartSettings {
   bool restartFromCheckpoint;
   bool restartFromBinaryFile;
   bool restartFromXSCFile;
+  /* sortBySegmentLabels, generateSegmentLabels are for consistent trajectory order across MC-MD cycles */
+  bool sortBySegmentLabels, generateSegmentLabels;
   bool operator()(void)
   {
     return enable;
@@ -111,7 +113,7 @@ struct FFKind {
 //Files for input.
 struct InFiles {
   std::vector<FileName> param;
-  FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput, checkpoint, referenceStructure;
+  FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput, checkpoint, referencePSF;
   FileName seed;
 };
 
@@ -876,7 +878,7 @@ struct Statistics {
 struct Output {
   SysState state, restart, state_dcd, restart_dcd;
   Statistics statistics;
-  EventSettings console, checkpoint;
+  EventSettings console, checkpoint, sortBySegmentLabels;
 };
 
 }

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -77,8 +77,6 @@ struct RestartSettings {
   bool restartFromCheckpoint;
   bool restartFromBinaryFile;
   bool restartFromXSCFile;
-  /* sortBySegmentLabels, generateSegmentLabels are for consistent trajectory order across MC-MD cycles */
-  bool sortBySegmentLabels, generateSegmentLabels;
   bool operator()(void)
   {
     return enable;

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -77,6 +77,7 @@ struct RestartSettings {
   bool restartFromCheckpoint;
   bool restartFromBinaryFile;
   bool restartFromXSCFile;
+  bool hybrid;
   bool operator()(void)
   {
     return enable;

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -111,7 +111,7 @@ struct FFKind {
 //Files for input.
 struct InFiles {
   std::vector<FileName> param;
-  FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput, checkpoint;
+  FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput, checkpoint, referenceStructure;
   FileName seed;
 };
 

--- a/src/DCDOutput.cpp
+++ b/src/DCDOutput.cpp
@@ -40,7 +40,7 @@ void DCDOutput::Init(pdb_setup::Atoms const& atoms,
   enableStateOut = output.state_dcd.settings.enable;
   enableRestartOut = output.restart.settings.enable;
   enableOut = enableStateOut | enableRestartOut;
-  enableSortedSegmentOut = output.sortBySegmentLabels.enable;
+  enableSortedSegmentOut = molRef.enableSortedSegmentOut;
   stepsStatePerOut = output.state_dcd.settings.frequency;
   stepsRestartPerOut = output.restart.settings.frequency;
   if (stepsStatePerOut < stepsRestartPerOut) {

--- a/src/DCDOutput.cpp
+++ b/src/DCDOutput.cpp
@@ -40,6 +40,7 @@ void DCDOutput::Init(pdb_setup::Atoms const& atoms,
   enableStateOut = output.state_dcd.settings.enable;
   enableRestartOut = output.restart.settings.enable;
   enableOut = enableStateOut | enableRestartOut;
+  enableSortedSegmentOut = output.sortBySegmentLabels.enable;
   stepsStatePerOut = output.state_dcd.settings.frequency;
   stepsRestartPerOut = output.restart.settings.frequency;
   if (stepsStatePerOut < stepsRestartPerOut) {
@@ -300,29 +301,32 @@ void DCDOutput::Write_binary_file(char *fname, int n, XYZ *vec)
 
 void DCDOutput::SetCoordinates(std::vector<int> &molInBox, const int box)
 {
-  uint p, pStart = 0, pEnd = 0;
+  uint p, pStart = 0, pEnd = 0, atomIndex = 0, mI = 0, pI = 0;
   int numMolecules = molRef.count;
   XYZ ref, coor;
 #if ENSEMBLE == NVT || ENSEMBLE == NPT
   //Loop through all molecules
   for (int m = 0; m < numMolecules; ++m) {
-    molRef.GetRangeStartStop(pStart, pEnd, m);
-    ref = comCurrRef.Get(m);
+    mI = enableSortedSegmentOut ? molRef.sortedMoleculeIndices[m] : m
+    molRef.GetRangeStartStop(pStart, pEnd, mI);
+    ref = comCurrRef.Get(mI);
     for (p = pStart; p < pEnd; ++p) {
       coor = coordCurrRef.Get(p);
       boxDimRef.UnwrapPBC(coor, box, ref);
 
-      x[p] = coor.x;
-      y[p] = coor.y;
-      z[p] = coor.z;
+      pI = enableSortedSegmentOut ? atomIndex : p;
+      x[pI] = coor.x;
+      y[pI] = coor.y;
+      z[pI] = coor.z;
+      ++atomIndex;
     }
   }
 #else
   bool inThisBox; 
   //Loop through all molecules
   for (int m = 0; m < numMolecules; ++m) {
-    molRef.GetRangeStartStop(pStart, pEnd, m);
-    ref = comCurrRef.Get(m);
+    mI = enableSortedSegmentOut ? molRef.sortedMoleculeIndices[m] : m;
+    molRef.GetRangeStartStop(pStart, pEnd, mI);
     inThisBox = (molInBox[m] == box);
     for (p = pStart; p < pEnd; ++p) {
       if (inThisBox) {
@@ -331,10 +335,11 @@ void DCDOutput::SetCoordinates(std::vector<int> &molInBox, const int box)
       } else {
         coor.Reset();
       }
-
-      x[p] = coor.x;
-      y[p] = coor.y;
-      z[p] = coor.z;
+      pI = enableSortedSegmentOut ? atomIndex : p;
+      x[pI] = coor.x;
+      y[pI] = coor.y;
+      z[pI] = coor.z;
+      ++atomIndex;
     }
   }
 #endif

--- a/src/DCDOutput.h
+++ b/src/DCDOutput.h
@@ -103,7 +103,7 @@ private:
   char *outXSTFile[BOX_TOTAL];
   char *outXSCFile[BOX_TOTAL];
   int stateFileFileid[BOX_TOTAL];
-  bool enableRestartOut, enableStateOut;
+  bool enableRestartOut, enableStateOut, enableSortedSegmentOut;
   ulong stepsRestartPerOut, stepsStatePerOut;
   // 
   float *x, *y, *z;

--- a/src/ExtendedSystem.h
+++ b/src/ExtendedSystem.h
@@ -42,6 +42,7 @@ class ExtendedSystem  {
     void UpdateCellBasis(PDBSetup &pdb, const int box);
     // Reads the binary coordinates and updates the X Y Z coordinates in pdb data structure
     void UpdateCoordinate(PDBSetup &pdb, const char *filename, const int box, MoleculeLookup & molLookup, Molecules & mols, int & cmIndex);
+    void UpdateCoordinateHybrid(PDBSetup &pdb, const char *filename, const int box);
     // the time steps in xsc file
     ulong firstStep;
     // Center of cell, but GOMC always uses 0 center

--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -354,11 +354,10 @@ void createKindMap (mol_setup::MoleculeVariables & molVars,
             molVars.startIdxMolecules.push_back(startIdxAtomBoxOffset + it->front());
             molVars.moleculeKinds.push_back((*kindMapFromBox1)[fragName].kindIndex);
             molVars.moleculeNames.push_back(fragName);
-            if(molVars.generateSegmentLabels){
-              molVars.moleculeSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
-            } else {
-              molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
-            }
+            if(molVars.generateSegmentLabels)
+              molVars.generatedSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
+            molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
+            
             /* Boilerplate PDB Data modifications for matches */
 
             /* Search current KindMap for this entry. 
@@ -459,11 +458,10 @@ void createKindMap (mol_setup::MoleculeVariables & molVars,
             molVars.startIdxMolecules.push_back(startIdxAtomBoxOffset + it->front());
             molVars.moleculeKinds.push_back(kindMap[*sizeConsistentEntries].kindIndex);
             molVars.moleculeNames.push_back(*sizeConsistentEntries);
-            if(molVars.generateSegmentLabels){
-              molVars.moleculeSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
-            } else {
-              molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
-            }
+            if(molVars.generateSegmentLabels)
+              molVars.generatedSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
+            molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
+            
             newMapEntry = false;
             break;
           }
@@ -519,11 +517,10 @@ void createKindMap (mol_setup::MoleculeVariables & molVars,
         molVars.moleculeKinds.push_back(kindMap[fragName].kindIndex);
         molVars.moleculeKindNames.push_back(fragName);
         molVars.moleculeNames.push_back(fragName);
-        if(molVars.generateSegmentLabels){
-          molVars.moleculeSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
-        } else {
-          molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
-        }
+        if(molVars.generateSegmentLabels)
+          molVars.generatedSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
+        molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
+        
         MolSetup::copyBondInfoIntoMapEntry(bondAdjList, kindMap, fragName);
         molVars.molKindIndex++;
         if (newSize){

--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -256,6 +256,7 @@ int MolSetup::Init(const bool restartIn,
   /* Sort the segments if the user states this is a restarted simulation since we
       automatically generate segment labels when outputting restart files */
   molVars.enableSortedSegmentOut = restartIn;
+  molVars.hybrid = pdbAtoms.hybrid;
   return ReadCombinePSF(molVars, kindMap, sizeMap, psfFilename, psfDefined, pdbAtoms);
 }
 

--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -242,15 +242,20 @@ int mol_setup::ReadCombinePSF(MoleculeVariables & molVars,
 
   return 0;
 }
-int MolSetup::Init(const config_setup::RestartSettings& restart,
+int MolSetup::Init(const bool restartIn,
+                   const bool restartOut,
                    const std::string* psfFilename, 
                    const bool* psfDefined, 
                    pdb_setup::Atoms& pdbAtoms)
 {
   kindMap.clear();
   sizeMap.clear();
-  molVars.generateSegmentLabels = restart.generateSegmentLabels;
-  molVars.sortBySegmentLabels = restart.sortBySegmentLabels;
+  /* Generate segment labels if this is the first time a simulation is called,
+    and the user enabled restart output */
+  molVars.generateSegmentLabels = !restartIn && restartOut;
+  /* Sort the segments if the user states this is a restarted simulation since we
+      automatically generate segment labels when outputting restart files */
+  molVars.sortBySegmentLabels = restartIn;
   return ReadCombinePSF(molVars, kindMap, sizeMap, psfFilename, psfDefined, pdbAtoms);
 }
 

--- a/src/MolSetup.cpp
+++ b/src/MolSetup.cpp
@@ -252,10 +252,10 @@ int MolSetup::Init(const bool restartIn,
   sizeMap.clear();
   /* Generate segment labels if this is the first time a simulation is called,
     and the user enabled restart output */
-  molVars.generateSegmentLabels = !restartIn && restartOut;
+  molVars.enableGenerateSegmentOut = !restartIn && restartOut;
   /* Sort the segments if the user states this is a restarted simulation since we
       automatically generate segment labels when outputting restart files */
-  molVars.sortBySegmentLabels = restartIn;
+  molVars.enableSortedSegmentOut = restartIn;
   return ReadCombinePSF(molVars, kindMap, sizeMap, psfFilename, psfDefined, pdbAtoms);
 }
 
@@ -359,7 +359,7 @@ void createKindMap (mol_setup::MoleculeVariables & molVars,
             molVars.startIdxMolecules.push_back(startIdxAtomBoxOffset + it->front());
             molVars.moleculeKinds.push_back((*kindMapFromBox1)[fragName].kindIndex);
             molVars.moleculeNames.push_back(fragName);
-            if(molVars.generateSegmentLabels)
+            if(molVars.enableGenerateSegmentOut)
               molVars.generatedSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
             molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
             
@@ -463,7 +463,7 @@ void createKindMap (mol_setup::MoleculeVariables & molVars,
             molVars.startIdxMolecules.push_back(startIdxAtomBoxOffset + it->front());
             molVars.moleculeKinds.push_back(kindMap[*sizeConsistentEntries].kindIndex);
             molVars.moleculeNames.push_back(*sizeConsistentEntries);
-            if(molVars.generateSegmentLabels)
+            if(molVars.enableGenerateSegmentOut)
               molVars.generatedSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
             molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
             
@@ -522,7 +522,7 @@ void createKindMap (mol_setup::MoleculeVariables & molVars,
         molVars.moleculeKinds.push_back(kindMap[fragName].kindIndex);
         molVars.moleculeKindNames.push_back(fragName);
         molVars.moleculeNames.push_back(fragName);
-        if(molVars.generateSegmentLabels)
+        if(molVars.enableGenerateSegmentOut)
           molVars.generatedSegmentNames.push_back(uniqueSuffixGenerator.uint2String(molVars.moleculeIteration));
         molVars.moleculeSegmentNames.push_back(allAtoms[it->front()].segment);
         

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -36,9 +36,9 @@ struct MoleculeVariables {
   uint molKindIndex = 0;
   uint stringSuffix = 0;
   uint moleculeIteration = 0;
-  /* sortBySegmentLabels, generateSegmentLabels are for consistent trajectory order across restarts */
-  bool generateSegmentLabels = false;
-  bool sortBySegmentLabels = false;
+  /* enableGenerateSegmentOut, enableSortedSegmentOut are for consistent trajectory order across restarts */
+  bool enableGenerateSegmentOut = false;
+  bool enableSortedSegmentOut = false;
 };
 
 //!structure to contain an atom's data during initialization

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -30,7 +30,7 @@ namespace mol_setup
 {
 struct MoleculeVariables {
   std::vector<uint> startIdxMolecules, moleculeKinds;
-  std::vector<std::string> moleculeNames, moleculeKindNames, moleculeSegmentNames;
+  std::vector<std::string> moleculeNames, moleculeKindNames, moleculeSegmentNames, generatedSegmentNames;
   uint lastAtomIndexInBox0 = 0;
   uint numberMolsInBox0 = 0;
   uint molKindIndex = 0;

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -36,6 +36,7 @@ struct MoleculeVariables {
   uint molKindIndex = 0;
   uint stringSuffix = 0;
   uint moleculeIteration = 0;
+  /* sortBySegmentLabels, generateSegmentLabels are for consistent trajectory order across restarts */
   bool generateSegmentLabels = false;
   bool sortBySegmentLabels = false;
 };
@@ -184,7 +185,8 @@ public:
 
   //reads BoxTotal PSFs and merges the data, placing the results in kindMap
   //returns 0 if read is successful, -1 on a failure
-  int Init(const config_setup::RestartSettings& restart,
+  int Init(const bool restartIn,
+           const bool restartOut,
            const std::string* psfFilename, 
            const bool* psfDefined, 
            pdb_setup::Atoms& pdbAtoms);

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -30,10 +30,14 @@ namespace mol_setup
 {
 struct MoleculeVariables {
   std::vector<uint> startIdxMolecules, moleculeKinds;
-  std::vector<std::string> moleculeNames, moleculeKindNames;
+  std::vector<std::string> moleculeNames, moleculeKindNames, moleculeSegmentNames;
   uint lastAtomIndexInBox0 = 0;
   uint numberMolsInBox0 = 0;
-  uint lastMolKindIndex = 0;
+  uint molKindIndex = 0;
+  uint stringSuffix = 0;
+  uint moleculeIteration = 0;
+  bool generateSegmentLabels = false;
+  bool sortBySegmentLabels = false;
 };
 
 //!structure to contain an atom's data during initialization
@@ -57,7 +61,9 @@ public:
   bool operator== (const Atom& atm) const
   {
     if (type == atm.type && 
-        charge == atm.charge)
+          charge == atm.charge && 
+            residue == atm.residue &&
+              mass == atm.mass)
       return true;
     else
       return false;

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -39,6 +39,7 @@ struct MoleculeVariables {
   /* enableGenerateSegmentOut, enableSortedSegmentOut are for consistent trajectory order across restarts */
   bool enableGenerateSegmentOut = false;
   bool enableSortedSegmentOut = false;
+  bool hybrid = false;
 };
 
 //!structure to contain an atom's data during initialization

--- a/src/MolSetup.h
+++ b/src/MolSetup.h
@@ -14,6 +14,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <map>
 #include "BondAdjacencyList.h"
+#include "AlphaNum.h"
 
 namespace config_setup
 {
@@ -31,6 +32,7 @@ struct MoleculeVariables {
   std::vector<uint> startIdxMolecules, moleculeKinds;
   std::vector<std::string> moleculeNames, moleculeKindNames;
   uint lastAtomIndexInBox0 = 0;
+  uint numberMolsInBox0 = 0;
   uint lastMolKindIndex = 0;
 };
 

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -54,7 +54,11 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   //chain = new char [atoms.x.size()];
   start = new uint [count + 1];
   sortedMoleculeIndices = new uint [count];
-  if(setup.mol.molVars.sortBySegmentLabels){
+
+  enableGenerateSegmentOut = setup.mol.molVars.enableGenerateSegmentOut;
+  enableSortedSegmentOut = setup.mol.molVars.enableSortedSegmentOut;
+
+  if(enableSortedSegmentOut){
     /* We need to create the sortedArray in the method and return it, instead of directly modifying the class' vector
      because of the way this class is initialized twice */
     SortMoleculesBySegment(setup.mol.molVars.moleculeSegmentNames);

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -48,21 +48,16 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
     std::cerr << "Error: No Molecule was found in the PSF file(s)!" << std::endl;
     exit(EXIT_FAILURE);
   }
-  chain = new char [atoms.x.size()];
+  //chain = new char [atoms.x.size()];
   start = new uint [count + 1];
   if(setup.mol.molVars.sortBySegmentLabels){
-    SortMoleculesBySegment( setup.mol.molVars.startIdxMolecules,
-                            setup.mol.molVars.moleculeKinds,
-                            atoms.chainLetter,
-                            setup.mol.molVars.moleculeSegmentNames,
-                            start,
-                            kIndex
-                            //, chain
-                          );
-  } else {
-    start = vect::TransferInto<uint>(start, setup.mol.molVars.startIdxMolecules);
-    kIndex = vect::transfer<uint>(setup.mol.molVars.moleculeKinds);
-  }
+    /* We need to create the sortedArray in the method and return it, instead of directly modifying the class' vector
+     because of the way this class is initialized twice */
+    this->sortedSegmentIndices = SortMoleculesBySegment( setup.mol.molVars.moleculeSegmentNames);
+  } 
+
+  start = vect::TransferInto<uint>(start, setup.mol.molVars.startIdxMolecules);
+  kIndex = vect::transfer<uint>(setup.mol.molVars.moleculeKinds);
   chain = vect::transfer<char>(atoms.chainLetter);
 
   start[count] = atoms.x.size();
@@ -245,21 +240,19 @@ void Molecules::PrintLJInfo(std::vector<uint> &totAtomKind,
   }
 }
 
-void Molecules::SortMoleculesBySegment(std::vector<uint> & unorderedStart,
-                                        std::vector<uint> & unorderedKIndex,
-                                        std::vector<char> & unorderedChain,
-                                        std::vector<std::string> & unorderedSegments,
-                                        uint * start,
-                                        uint * kIndex
-                                        //, char * chain
-                                      ){
+std::vector<uint>  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegments){
 
   /* For Hybid MC-MD Cycle Consistency between molecular order
      Sort these three vectors according to alphanmeric segment label */ 
+
+  /* Since we call this method twice, due to reinitialization pattern for ewald */
+  //sortedSegmentName.clear(); 
+  //sortedSegmentIndices.clear(); 
+
+  std::vector<std::string> sortedSegmentName(count);
+  std::vector<uint> sortedSegmentIndices(count);
+
   std::vector<uint> unsortedSegmentIndices(count);
-  std::vector<uint> sortedStart(count);
-  std::vector<uint> sortedKIndex(count);
-  std::vector<char> sortedChain(count);
   std::iota(unsortedSegmentIndices.begin(), unsortedSegmentIndices.end(), 0);
   //declaring vector of pairs
   std::vector< std::pair <std::string,uint> > pairVector;
@@ -271,17 +264,11 @@ void Molecules::SortMoleculesBySegment(std::vector<uint> & unorderedStart,
   std::sort(pairVector.begin(), pairVector.end());
 
   for (int i = 0; i < count; i++){
-    sortedStart.push_back(unorderedStart[pairVector[i].second]);  
-    sortedKIndex.push_back(unorderedKIndex[pairVector[i].second]);  
-    sortedChain.push_back(unorderedChain[pairVector[i].second]);  
     sortedSegmentName.push_back(unorderedSegments[pairVector[i].second]); 
     sortedSegmentIndices.push_back(pairVector[i].second); 
   }
 
-  start = vect::TransferInto<uint>(start, sortedStart);
-  kIndex = vect::transfer<uint>(sortedKIndex);
-  //chain = vect::transfer<char>(sortedChain);
-
+  return sortedSegmentIndices;
   /* For Hybid MC-MD Cycle Consistency between molecular order
     Sort these three vectors according to alphanmeric segment label */ 
 

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -48,7 +48,7 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
     std::cerr << "Error: No Molecule was found in the PSF file(s)!" << std::endl;
     exit(EXIT_FAILURE);
   }
-
+  chain = new char [atoms.x.size()];
   start = new uint [count + 1];
   if(setup.mol.molVars.sortBySegmentLabels){
     SortMoleculesBySegment( setup.mol.molVars.startIdxMolecules,
@@ -56,14 +56,15 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
                             atoms.chainLetter,
                             setup.mol.molVars.moleculeSegmentNames,
                             start,
-                            kIndex,
-                            chain
+                            kIndex
+                            //, chain
                           );
   } else {
     start = vect::TransferInto<uint>(start, setup.mol.molVars.startIdxMolecules);
     kIndex = vect::transfer<uint>(setup.mol.molVars.moleculeKinds);
     chain = vect::transfer<char>(atoms.chainLetter);
   }
+
 
   start[count] = atoms.x.size();
   kIndexCount = setup.mol.molVars.moleculeKinds.size();
@@ -250,36 +251,37 @@ void Molecules::SortMoleculesBySegment(std::vector<uint> & unorderedStart,
                                         std::vector<char> & unorderedChain,
                                         std::vector<std::string> & unorderedSegments,
                                         uint * start,
-                                        uint * kIndex,
-                                        char * chain
+                                        uint * kIndex
+                                        //, char * chain
                                       ){
 
   /* For Hybid MC-MD Cycle Consistency between molecular order
      Sort these three vectors according to alphanmeric segment label */ 
-  std::vector<uint> sortedSegmentIndices(count);
+  std::vector<uint> unsortedSegmentIndices(count);
   std::vector<uint> sortedStart(count);
   std::vector<uint> sortedKIndex(count);
   std::vector<char> sortedChain(count);
-  std::iota(sortedSegmentIndices.begin(), sortedSegmentIndices.end(), 0);
+  std::iota(unsortedSegmentIndices.begin(), unsortedSegmentIndices.end(), 0);
   //declaring vector of pairs
   std::vector< std::pair <std::string,uint> > pairVector;
   // Entering values in vector of pairs
   for (int i=0; i<count; i++)
-      pairVector.push_back( std::make_pair(unorderedSegments[i],sortedSegmentIndices[i]) );
+      pairVector.push_back( std::make_pair(unorderedSegments[i],unsortedSegmentIndices[i]) );
 
   // Using simple sort() function to sort
   std::sort(pairVector.begin(), pairVector.end());
 
   for (int i = 0; i < count; i++){
-    sortedStart.push_back(unorderedStart[sortedSegmentIndices[i]]);  
-    sortedKIndex.push_back(unorderedKIndex[sortedSegmentIndices[i]]);  
-    sortedChain.push_back(unorderedChain[sortedSegmentIndices[i]]);  
-    sortedSegmentLabel.push_back(unorderedSegments[sortedSegmentIndices[i]]);  
+    sortedStart.push_back(unorderedStart[pairVector[i].second]);  
+    sortedKIndex.push_back(unorderedKIndex[pairVector[i].second]);  
+    sortedChain.push_back(unorderedChain[pairVector[i].second]);  
+    sortedSegmentName.push_back(unorderedSegments[pairVector[i].second]); 
+    sortedSegmentIndices.push_back(pairVector[i].second); 
   }
 
   start = vect::TransferInto<uint>(start, sortedStart);
   kIndex = vect::transfer<uint>(sortedKIndex);
-  chain = vect::transfer<char>(sortedChain);
+  //chain = vect::transfer<char>(sortedChain);
 
   /* For Hybid MC-MD Cycle Consistency between molecular order
     Sort these three vectors according to alphanmeric segment label */ 

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -21,7 +21,7 @@ class System;
 Molecules::Molecules() : start(NULL), kIndex(NULL), countByKind(NULL),
   chain(NULL), kinds(NULL), pairEnCorrections(NULL),
   pairVirCorrections(NULL), printFlag(true), sortedMoleculeSegmentName(NULL), 
-  sortedMoleculeIndices(NULL), sortedStart(NULL), sortedKIndex(NULL){}
+  sortedMoleculeIndices(NULL){}
 
 Molecules::~Molecules(void)
 {
@@ -34,8 +34,6 @@ Molecules::~Molecules(void)
   delete[] pairVirCorrections;
   delete[] sortedMoleculeSegmentName;
   delete[] sortedMoleculeIndices;
-  delete[] sortedStart;
-  delete[] sortedKIndex;
 }
 
 void Molecules::Init(Setup & setup, Forcefield & forcefield,
@@ -57,14 +55,9 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   start = new uint [count + 1];
   sortedMoleculeIndices = new uint [count];
   if(setup.mol.molVars.sortBySegmentLabels){
-    sortedStart = new uint [count + 1];
     /* We need to create the sortedArray in the method and return it, instead of directly modifying the class' vector
      because of the way this class is initialized twice */
-    SortMoleculesBySegment( setup.mol.molVars.moleculeSegmentNames,
-                            setup.mol.molVars.startIdxMolecules,
-                            setup.mol.molVars.moleculeKinds
-                          );
-    sortedStart[count] = atoms.x.size();          
+    SortMoleculesBySegment(setup.mol.molVars.moleculeSegmentNames);
   }
 
   start = vect::TransferInto<uint>(start, setup.mol.molVars.startIdxMolecules);
@@ -251,19 +244,13 @@ void Molecules::PrintLJInfo(std::vector<uint> &totAtomKind,
   }
 }
 
-void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegments,
-                                        std::vector<uint> & unorderedStart,
-                                        std::vector<uint> & unorderedKIndex
-                                        ){
+void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegments){
 
   /* For Hybid MC-MD Cycle Consistency between molecular order
      Sort these three vectors according to alphanmeric segment label */ 
 
   std::vector<std::string> sortedSegmentName;
   std::vector<uint> sortedSegmentIndices;
-  std::vector<uint> sortedStartVec;
-  std::vector<uint> sortedKIndexVec;
-
 
   std::vector<uint> unsortedSegmentIndices(count);
   std::iota(unsortedSegmentIndices.begin(), unsortedSegmentIndices.end(), 0);
@@ -277,16 +264,12 @@ void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegm
   std::sort(pairVector.begin(), pairVector.end(), compare());
 
   for (int i = 0; i < count; i++){
-    sortedStartVec.push_back(unorderedStart[pairVector[i].second]);  
-    sortedKIndexVec.push_back(unorderedKIndex[pairVector[i].second]);  
     sortedSegmentName.push_back(unorderedSegments[pairVector[i].second]); 
     sortedSegmentIndices.push_back(pairVector[i].second); 
   }
 
 
   vect::TransferInto<uint>(this->sortedMoleculeIndices, sortedSegmentIndices);
-  sortedStart = vect::TransferInto<uint>(sortedStart, sortedStartVec);
-  sortedKIndex = vect::transfer<uint>(sortedKIndexVec);
   //chain = vect::transfer<char>(sortedChain);
   //return sortedSegmentIndices;
   /* For Hybid MC-MD Cycle Consistency between molecular order

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -260,7 +260,7 @@ void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegm
       pairVector.push_back( std::make_pair(unorderedSegments[i],unsortedSegmentIndices[i]) );
 
   // Using simple sort() function to sort
-  std::sort(pairVector.begin(), pairVector.end());
+  std::sort(pairVector.begin(), pairVector.end(), compare());
 
   for (int i = 0; i < count; i++){
     sortedSegmentName.push_back(unorderedSegments[pairVector[i].second]); 

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -20,7 +20,8 @@ class System;
 
 Molecules::Molecules() : start(NULL), kIndex(NULL), countByKind(NULL),
   chain(NULL), kinds(NULL), pairEnCorrections(NULL),
-  pairVirCorrections(NULL), printFlag(true), sortedMoleculeSegmentName(NULL), sortedMoleculeIndices(NULL){}
+  pairVirCorrections(NULL), printFlag(true), sortedMoleculeSegmentName(NULL), 
+  sortedMoleculeIndices(NULL), sortedStart(NULL), sortedKIndex(NULL){}
 
 Molecules::~Molecules(void)
 {
@@ -33,6 +34,8 @@ Molecules::~Molecules(void)
   delete[] pairVirCorrections;
   delete[] sortedMoleculeSegmentName;
   delete[] sortedMoleculeIndices;
+  delete[] sortedStart;
+  delete[] sortedKIndex;
 }
 
 void Molecules::Init(Setup & setup, Forcefield & forcefield,
@@ -54,10 +57,15 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   start = new uint [count + 1];
   sortedMoleculeIndices = new uint [count];
   if(setup.mol.molVars.sortBySegmentLabels){
+    sortedStart = new uint [count + 1];
     /* We need to create the sortedArray in the method and return it, instead of directly modifying the class' vector
      because of the way this class is initialized twice */
-    SortMoleculesBySegment( setup.mol.molVars.moleculeSegmentNames);
-  } 
+    SortMoleculesBySegment( setup.mol.molVars.moleculeSegmentNames,
+                            setup.mol.molVars.startIdxMolecules,
+                            setup.mol.molVars.moleculeKinds
+                          );
+    sortedStart[count] = atoms.x.size();          
+  }
 
   start = vect::TransferInto<uint>(start, setup.mol.molVars.startIdxMolecules);
   kIndex = vect::transfer<uint>(setup.mol.molVars.moleculeKinds);
@@ -243,13 +251,19 @@ void Molecules::PrintLJInfo(std::vector<uint> &totAtomKind,
   }
 }
 
-void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegments){
+void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegments,
+                                        std::vector<uint> & unorderedStart,
+                                        std::vector<uint> & unorderedKIndex
+                                        ){
 
   /* For Hybid MC-MD Cycle Consistency between molecular order
      Sort these three vectors according to alphanmeric segment label */ 
 
   std::vector<std::string> sortedSegmentName;
   std::vector<uint> sortedSegmentIndices;
+  std::vector<uint> sortedStartVec;
+  std::vector<uint> sortedKIndexVec;
+
 
   std::vector<uint> unsortedSegmentIndices(count);
   std::iota(unsortedSegmentIndices.begin(), unsortedSegmentIndices.end(), 0);
@@ -263,12 +277,17 @@ void  Molecules::SortMoleculesBySegment(std::vector<std::string> & unorderedSegm
   std::sort(pairVector.begin(), pairVector.end(), compare());
 
   for (int i = 0; i < count; i++){
+    sortedStartVec.push_back(unorderedStart[pairVector[i].second]);  
+    sortedKIndexVec.push_back(unorderedKIndex[pairVector[i].second]);  
     sortedSegmentName.push_back(unorderedSegments[pairVector[i].second]); 
     sortedSegmentIndices.push_back(pairVector[i].second); 
   }
 
 
   vect::TransferInto<uint>(this->sortedMoleculeIndices, sortedSegmentIndices);
+  sortedStart = vect::TransferInto<uint>(sortedStart, sortedStartVec);
+  sortedKIndex = vect::transfer<uint>(sortedKIndexVec);
+  //chain = vect::transfer<char>(sortedChain);
   //return sortedSegmentIndices;
   /* For Hybid MC-MD Cycle Consistency between molecular order
     Sort these three vectors according to alphanmeric segment label */ 

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -45,7 +45,7 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   //Molecule instance arrays/data
   count = setup.mol.molVars.startIdxMolecules.size();
   if (count == 0) {
-    std::cerr << "Error: No Molecule was found in the PDB file(s)!" << std::endl;
+    std::cerr << "Error: No Molecule was found in the PSF file(s)!" << std::endl;
     exit(EXIT_FAILURE);
   }
 

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -62,9 +62,8 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   } else {
     start = vect::TransferInto<uint>(start, setup.mol.molVars.startIdxMolecules);
     kIndex = vect::transfer<uint>(setup.mol.molVars.moleculeKinds);
-    chain = vect::transfer<char>(atoms.chainLetter);
   }
-
+  chain = vect::transfer<char>(atoms.chainLetter);
 
   start[count] = atoms.x.size();
   kIndexCount = setup.mol.molVars.moleculeKinds.size();

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -84,12 +84,6 @@ public:
     stop = start[m + 1];
   }
 
-  void GetRangeStartStopSorted(uint & _start, uint & stop, const uint m) const
-  {
-    _start = sortedStart[m];
-    stop = sortedStart[m + 1];
-  }
-
   void GetRangeStartLength(uint & _start, uint & len, const uint m) const
   {
     _start = start[m];
@@ -105,9 +99,7 @@ public:
                    std::vector<std::string> &names,
                    Forcefield & forcefield);
 
-  void SortMoleculesBySegment(std::vector<std::string> & unorderedSegments,
-                                        std::vector<uint> & unorderedStart,
-                                        std::vector<uint> & unorderedKIndex);
+  void SortMoleculesBySegment(std::vector<std::string> & unorderedSegments);
 
   //private:
   //Kind index of each molecule and start in master particle array
@@ -119,9 +111,6 @@ public:
   uint* countByKind;
   char* chain;
 
-  uint *  sortedMoleculeIndices;
-  uint * sortedStart;
-  uint * sortedKIndex;
 
   MoleculeKind * kinds;
   uint kindsCount;
@@ -130,6 +119,7 @@ public:
   double* pairVirCorrections;
 
   /* For Hybrid MC-MD Order Consistency B/w cycles */
+  uint *  sortedMoleculeIndices;
   /* Only used for testing purposes */
   std::string * sortedMoleculeSegmentName;
 

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -122,6 +122,8 @@ public:
   uint *  sortedMoleculeIndices;
   /* Only used for testing purposes */
   std::string * sortedMoleculeSegmentName;
+  bool enableSortedSegmentOut, enableGenerateSegmentOut;
+  bool generateSegmentName;
 
   bool printFlag;
 };

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -95,7 +95,7 @@ public:
                    std::vector<std::string> &names,
                    Forcefield & forcefield);
 
-  std::vector<uint> SortMoleculesBySegment(std::vector<std::string> & unorderedSegments);
+  void SortMoleculesBySegment(std::vector<std::string> & unorderedSegments);
 
   //private:
   //Kind index of each molecule and start in master particle array
@@ -107,6 +107,8 @@ public:
   uint* countByKind;
   char* chain;
 
+  uint *  sortedMoleculeIndices;
+
   MoleculeKind * kinds;
   uint kindsCount;
   uint fractionKind, lambdaSize;
@@ -115,8 +117,8 @@ public:
 
   /* For Hybrid MC-MD Order Consistency B/w cycles */
   /* Only used for testing purposes */
-  std::vector<std::string> sortedSegmentName;
-  std::vector<uint> sortedSegmentIndices;
+  std::string * sortedMoleculeSegmentName;
+
   bool printFlag;
 };
 

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -11,6 +11,8 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "MolSetup.h"
 #include <map>
 #include <string>
+// For iota
+#include <numeric>
 
 namespace pdb_setup
 {
@@ -93,6 +95,14 @@ public:
                    std::vector<std::string> &names,
                    Forcefield & forcefield);
 
+  void SortMoleculesBySegment(std::vector<uint> & unorderedStart,
+                              std::vector<uint> & unorderedKIndex,
+                              std::vector<char> & unorderedChain,
+                              std::vector<std::string> & segments,
+                              uint * start,
+                              uint * kIndex,
+                              char * chain);
+
   //private:
   //Kind index of each molecule and start in master particle array
   //Plus counts
@@ -108,6 +118,9 @@ public:
   uint fractionKind, lambdaSize;
   double* pairEnCorrections;
   double* pairVirCorrections;
+
+  /* For Hybrid MC-MD Order Consistency B/w cycles */
+  std::vector<std::string> sortedSegmentLabel;
 
   bool printFlag;
 };

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -83,6 +83,13 @@ public:
     _start = start[m];
     stop = start[m + 1];
   }
+
+  void GetRangeStartStopSorted(uint & _start, uint & stop, const uint m) const
+  {
+    _start = sortedStart[m];
+    stop = sortedStart[m + 1];
+  }
+
   void GetRangeStartLength(uint & _start, uint & len, const uint m) const
   {
     _start = start[m];
@@ -98,7 +105,9 @@ public:
                    std::vector<std::string> &names,
                    Forcefield & forcefield);
 
-  void SortMoleculesBySegment(std::vector<std::string> & unorderedSegments);
+  void SortMoleculesBySegment(std::vector<std::string> & unorderedSegments,
+                                        std::vector<uint> & unorderedStart,
+                                        std::vector<uint> & unorderedKIndex);
 
   //private:
   //Kind index of each molecule and start in master particle array
@@ -111,6 +120,8 @@ public:
   char* chain;
 
   uint *  sortedMoleculeIndices;
+  uint * sortedStart;
+  uint * sortedKIndex;
 
   MoleculeKind * kinds;
   uint kindsCount;

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -13,6 +13,9 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include <string>
 // For iota
 #include <numeric>
+// For custom sort 
+#include "AlphaNum.h"
+
 
 namespace pdb_setup
 {

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -100,8 +100,9 @@ public:
                               std::vector<char> & unorderedChain,
                               std::vector<std::string> & segments,
                               uint * start,
-                              uint * kIndex,
-                              char * chain);
+                              uint * kIndex
+                              //, char * chain
+                            );
 
   //private:
   //Kind index of each molecule and start in master particle array
@@ -120,8 +121,9 @@ public:
   double* pairVirCorrections;
 
   /* For Hybrid MC-MD Order Consistency B/w cycles */
-  std::vector<std::string> sortedSegmentLabel;
-
+  /* Only used for testing purposes */
+  std::vector<std::string> sortedSegmentName;
+  std::vector<uint> sortedSegmentIndices;
   bool printFlag;
 };
 

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -95,14 +95,7 @@ public:
                    std::vector<std::string> &names,
                    Forcefield & forcefield);
 
-  void SortMoleculesBySegment(std::vector<uint> & unorderedStart,
-                              std::vector<uint> & unorderedKIndex,
-                              std::vector<char> & unorderedChain,
-                              std::vector<std::string> & segments,
-                              uint * start,
-                              uint * kIndex
-                              //, char * chain
-                            );
+  std::vector<uint> SortMoleculesBySegment(std::vector<std::string> & unorderedSegments);
 
   //private:
   //Kind index of each molecule and start in master particle array

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -110,11 +110,15 @@ void PDBOutput::InitPartVec()
       for (uint p = pStart; p < pEnd; ++p) {
         pI = enableSortedSegmentOut ? atomIndex : p;
         if (molRef.kinds[molRef.kIndex[mI]].isMultiResidue){
-          FormatAtom(pStr[pI], pI, molecule + molRef.kinds[molRef.kIndex[mI]].intraMoleculeResIDs[p - pStart], molRef.chain[molRef.kIndex[mI]],
-                    molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
+          FormatAtom(pStr[pI], pI, molecule + molRef.kinds[molRef.kIndex[mI]].intraMoleculeResIDs[p - pStart], 
+                    molRef.chain[mI + (p - pStart)],
+                    molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], 
+                    molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
         } else {
-          FormatAtom(pStr[pI], pI, molecule, molRef.chain[molRef.kIndex[mI]],
-                    molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
+          FormatAtom(pStr[pI], pI, molecule, 
+                    molRef.chain[mI + (p - pStart)],
+                    molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], 
+                    molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
         }
         ++atomIndex;
       }

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -142,27 +142,25 @@ void PDBOutput::InitPartVecSorted()
     MoleculeLookup::box_iterator m = molLookupRef.BoxBegin(b),
                                  end = molLookupRef.BoxEnd(b);
     while (m != end) {
-      uint mI = *m;
+      uint mI = molRef.sortedMoleculeIndices[*m];
 
-      molRef.GetRangeStartStop(pStart, pEnd, molRef.sortedMoleculeIndices[mI]);
+      molRef.GetRangeStartStop(pStart, pEnd, mI);
 
       for (uint p = pStart; p < pEnd; ++p) {
-        if (molRef.kinds[molRef.sortedKIndex[mI]].isMultiResidue){
-          FormatAtom(pStr[atomIndex], atomIndex, molecule + molRef.kinds[molRef.sortedKIndex[mI]].intraMoleculeResIDs[p - pStart], molRef.chain[molRef.sortedKIndex[mI]],
-                    molRef.kinds[molRef.sortedKIndex[mI]].atomNames[p - pStart], molRef.kinds[molRef.sortedKIndex[mI]].resNames[p - pStart]);
+        if (molRef.kinds[molRef.kIndex[mI]].isMultiResidue){
+          FormatAtom(pStr[atomIndex], atomIndex, molecule + molRef.kinds[molRef.kIndex[mI]].intraMoleculeResIDs[p - pStart], molRef.chain[molRef.kIndex[mI]],
+                    molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
         } else {
-          std::cout << molRef.kinds[molRef.sortedKIndex[mI]].atomNames[p - pStart] << std::endl;
-           std::cout << molRef.kinds[molRef.sortedKIndex[mI]].resNames[p - pStart]<< std::endl;
-          FormatAtom(pStr[atomIndex], atomIndex, molecule, molRef.chain[molRef.sortedKIndex[mI]],
-                    molRef.kinds[molRef.sortedKIndex[mI]].atomNames[p - pStart], molRef.kinds[molRef.sortedKIndex[mI]].resNames[p - pStart]);
+          FormatAtom(pStr[atomIndex], atomIndex, molecule, molRef.chain[molRef.kIndex[mI]],
+                    molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
         }
         atomIndex++;
       }
       ++m;
       ++molecule;
       /* If you want to keep orig resID's comment these out */
-      if (molRef.kinds[molRef.sortedKIndex[mI]].isMultiResidue){
-        molecule += molRef.kinds[molRef.sortedKIndex[mI]].intraMoleculeResIDs.back();
+      if (molRef.kinds[molRef.kIndex[mI]].isMultiResidue){
+        molecule += molRef.kinds[molRef.kIndex[mI]].intraMoleculeResIDs.back();
       }
       /* 0 & 9999 since FormatAtom adds 1 shifting to 1 and 10,000*/
       if(molecule == 9999)
@@ -394,7 +392,6 @@ void PDBOutput::PrintAtomsSorted(const uint b, std::vector<uint> & mBox)
         boxDimRef.UnwrapPBC(coor, b, ref);
       }
       InsertAtomInLine(pStr[atomIndex], coor, occupancy::BOX[mBox[sortedMolIndex]], beta::FIX[beta]);
-      //Write finished string out.
       outF[b].file << pStr[atomIndex] << std::endl;
       ++atomIndex;
     }

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -42,7 +42,7 @@ void PDBOutput::Init(pdb_setup::Atoms const& atoms,
   sstrm::Converter toStr;
   enableOutState = output.state.settings.enable;
   enableRestOut = output.restart.settings.enable;
-  enableSortedSegmentOut = output.sortBySegmentLabels.enable;
+  enableSortedSegmentOut = molRef.enableSortedSegmentOut;
   enableOut = enableOutState | enableRestOut;
   stepsCoordPerOut = output.state.settings.frequency;
   stepsRestPerOut = output.restart.settings.frequency;

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -407,6 +407,7 @@ void PDBOutput::PrintAtomsRebuildRestart(const uint b, std::vector<uint> & mBox)
                   molRef.kinds[k].atomNames[p - pStart], molRef.kinds[k].resNames[p - pStart]);
       }
       //Fill in particle's stock string with new x, y, z, and occupancy
+      /* In NAMD FE -1 == on, 1 == off , when lambda is fixed at 0*/
       InsertAtomInLine(line, coor, inThisBox ? "-1.00" : "1.00", beta::FIX[beta]);
       //Write finished string out.
       outRebuildRestart[b].file << line << std::endl;

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -108,15 +108,16 @@ void PDBOutput::InitPartVec()
       molRef.GetRangeStartStop(pStart, pEnd, mI);
 
       for (uint p = pStart; p < pEnd; ++p) {
+        molecule = enableSortedSegmentOut ? molecule : mI;
         pI = enableSortedSegmentOut ? atomIndex : p;
         if (molRef.kinds[molRef.kIndex[mI]].isMultiResidue){
           FormatAtom(pStr[pI], pI, molecule + molRef.kinds[molRef.kIndex[mI]].intraMoleculeResIDs[p - pStart], 
-                    molRef.chain[mI + (p - pStart)],
+                    molRef.chain[p],
                     molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], 
                     molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
         } else {
           FormatAtom(pStr[pI], pI, molecule, 
-                    molRef.chain[mI + (p - pStart)],
+                    molRef.chain[p],
                     molRef.kinds[molRef.kIndex[mI]].atomNames[p - pStart], 
                     molRef.kinds[molRef.kIndex[mI]].resNames[p - pStart]);
         }

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -41,6 +41,7 @@ void PDBOutput::Init(pdb_setup::Atoms const& atoms,
   sstrm::Converter toStr;
   enableOutState = output.state.settings.enable;
   enableRestOut = output.restart.settings.enable;
+  enableSortedSegmentOut = output.sortBySegmentLabels.enable;
   enableOut = enableOutState | enableRestOut;
   stepsCoordPerOut = output.state.settings.frequency;
   stepsRestPerOut = output.restart.settings.frequency;
@@ -68,7 +69,11 @@ void PDBOutput::Init(pdb_setup::Atoms const& atoms,
       outF[b].Init(output.state.files.pdb.name[b], aliasStr, true, notify);
       outF[b].open();
     }
-    InitPartVec();
+    if (enableSortedSegmentOut){
+      InitPartVecSorted();
+    } else {
+      InitPartVec();
+    }
     DoOutput(0);
   }
 
@@ -127,6 +132,13 @@ void PDBOutput::InitPartVec()
     }
   }
 }
+
+/* We need to do this in the sorted molecule order, using the alphanumberic keys stored in segment column from reference merged_psf */
+void PDBOutput::InitPartVecSorted()
+{
+
+}
+
 
 void PDBOutput::FormatAtom
 (std::string & line, const uint p, const uint m, const char chain,

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -50,6 +50,7 @@ private:
   std::string GetDefaultAtomStr();
 
   void InitPartVec();
+  void InitPartVecSorted();
 
   void SetMolBoxVec(std::vector<uint> & mBox);
 
@@ -91,7 +92,7 @@ private:
 
   Writer outF[BOX_TOTAL];
   Writer outRebuildRestart[BOX_TOTAL];
-  bool enableRestOut;
+  bool enableRestOut, enableSortedSegmentOut;
   ulong stepsRestPerOut;
   ulong stepsCoordPerOut;
   //NEW_RESTART_CODE

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -100,7 +100,7 @@ private:
   //NEW_RESTART_CODE
   bool enableOutState;
   std::vector<std::string> pStr;
-  std::vector<int> sortedSegmentIndices;
+  //std::vector<int> sortedSegmentIndices;
   int frameNumber[BOX_TOTAL];
 };
 

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -59,6 +59,7 @@ private:
 
   //NEW_RESTART_CODE
   void DoOutputRebuildRestart(const uint step);
+  void PrintAtomsRebuildRestart(const uint b, std::vector<uint> & mBox);
   void PrintAtomsRebuildRestart(const uint b);
   void PrintCrystRest(const uint b, const uint step, Writer & out);
   void PrintRemark(const uint b, const uint step, Writer & out);
@@ -98,6 +99,8 @@ private:
   bool enableOutState;
   std::vector<std::string> pStr;
   int frameNumber[BOX_TOTAL];
+
+  bool hybrid = true;
 };
 
 #endif /*PDB_OUTPUT_H*/

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -50,15 +50,12 @@ private:
   std::string GetDefaultAtomStr();
 
   void InitPartVec();
-  void InitPartVecSorted();
 
   void SetMolBoxVec(std::vector<uint> & mBox);
 
   void PrintCryst1(const uint b, Writer & out);
 
   void PrintAtoms(const uint b, std::vector<uint> & mBox);
-  void PrintAtomsSorted(const uint b, std::vector<uint> & mBox);
-
 
   //NEW_RESTART_CODE
   void DoOutputRebuildRestart(const uint step);

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -100,7 +100,6 @@ private:
   //NEW_RESTART_CODE
   bool enableOutState;
   std::vector<std::string> pStr;
-  //std::vector<int> sortedSegmentIndices;
   int frameNumber[BOX_TOTAL];
 };
 

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -57,6 +57,8 @@ private:
   void PrintCryst1(const uint b, Writer & out);
 
   void PrintAtoms(const uint b, std::vector<uint> & mBox);
+  void PrintAtomsSorted(const uint b, std::vector<uint> & mBox);
+
 
   //NEW_RESTART_CODE
   void DoOutputRebuildRestart(const uint step);
@@ -98,6 +100,7 @@ private:
   //NEW_RESTART_CODE
   bool enableOutState;
   std::vector<std::string> pStr;
+  std::vector<int> sortedSegmentIndices;
   int frameNumber[BOX_TOTAL];
 };
 

--- a/src/PDBSetup.cpp
+++ b/src/PDBSetup.cpp
@@ -103,6 +103,7 @@ void Atoms::SetRestart(config_setup::RestartSettings const& r )
 {
   restart = r.enable;
   recalcTrajectory = r.recalcTrajectory;
+  restartFromCheckpoint = r.restartFromCheckpoint;
 }
 
 void Atoms::Assign(std::string const& resName,
@@ -139,6 +140,12 @@ void Atoms::Read(FixedWidthReader & file)
   .Get(l_y, field::y::POS).Get(l_z, field::z::POS)
   .Get(l_occ, field::occupancy::POS)
   .Get(l_beta, field::beta::POS);
+  /* In Hybrid MC-MD, we use occupancy as -1 == currBox, 1 == otherBox */
+  if(hybrid)
+    if(l_occ == -1.00)
+      l_occ = currBox;
+    else
+      return;
   if(recalcTrajectory && (uint)l_occ != currBox) {
     return;
   }

--- a/src/PDBSetup.h
+++ b/src/PDBSetup.h
@@ -47,6 +47,7 @@ struct Remarks : FWReadableBase {
   }
 
   void SetRestart(config_setup::RestartSettings const& r);
+  /* Add uint b, so I can tell pass this if I encounted Occupancy == -1 */
   void Read(FixedWidthReader & pdb);
   void SetBox(const uint b)
   {
@@ -110,13 +111,14 @@ public:
   void Clear();
 
   //private:
+  bool hybrid = true;
   //member data
   std::vector<char> chainLetter; //chain ids of each atom respectively
   std::vector<double> x, y, z; //coordinates of each particle
   std::vector<double> beta;  //beta value of each molecule
   std::vector<uint> box;
   std::vector<std::string> resNames;
-  bool restart, firstResInFile, recalcTrajectory;
+  bool restart, firstResInFile, recalcTrajectory, restartFromCheckpoint;
   //CurrRes is used to store res vals, currBox is used to
   //determine box either via the file (new) or the occupancy
   //(restart), count allows overwriting of coordinates during

--- a/src/PDBSetup.h
+++ b/src/PDBSetup.h
@@ -112,6 +112,7 @@ public:
 
   //private:
   bool hybrid = true;
+  std::vector<int> inThisBox;
   //member data
   std::vector<char> chainLetter; //chain ids of each atom respectively
   std::vector<double> x, y, z; //coordinates of each particle

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -201,6 +201,7 @@ void PSFOutput::PrintRemarks(FILE* outfile, const std::vector<std::string>& rema
 
 void PSFOutput::PrintAtoms(FILE* outfile) const
 {
+  AlphaNum fixedOrder;
   fprintf(outfile, headerFormat, totalAtoms, atomHeader);
   //silly psfs index from 1
   uint atomID = 1;
@@ -215,14 +216,24 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
       //atom name, atom type, charge, mass, and an unused 0
 
       if(molKinds[thisKind].isMultiResidue){
-        fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+        fprintf(outfile, atomFormat, atomID, fixedOrder.uint2String(mol).c_str(),
                 resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                 thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
       } else {
-        fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+        fprintf(outfile, atomFormat, atomID, fixedOrder.uint2String(mol).c_str(),
                 resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                 thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
       }
+/*      if(molKinds[thisKind].isMultiResidue){
+          fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+                  resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
+                  thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
+        } else {
+          fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+                  resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
+                  thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
+        }
+*/      
       ++atomID;
     }
     /* This isn't actually residue, it is running count of the number of

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -40,7 +40,8 @@ PSFOutput::PSFOutput(const Molecules& molecules, const System &sys,
   molNames(set.mol.molVars.moleculeKindNames), 
   generateSegmentLabels(set.mol.molVars.generateSegmentLabels),
   enableSortedSegmentOut (set.mol.molVars.sortBySegmentLabels),
-  moleculeSegmentNames(set.mol.molVars.moleculeSegmentNames)
+  moleculeSegmentNames(set.mol.molVars.moleculeSegmentNames),
+  generatedSegmentNames(set.mol.molVars.generatedSegmentNames)
 {
   molKinds.resize(set.mol.kindMap.size());
  for(uint i = 0; i < set.mol.molVars.moleculeKindNames.size(); ++i) {
@@ -357,11 +358,16 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
         //atom name, atom type, charge, mass, and an unused 0
 
         if(molKinds[thisKind].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, moleculeSegmentNames[*thisMol].c_str(),
-                  resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
+          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? 
+                  generatedSegmentNames[*thisMol].c_str() : 
+                  moleculeSegmentNames[*thisMol].c_str(),
+                  resID + molKinds[thisKind].intraMoleculeResIDs[at], 
+                  thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, moleculeSegmentNames[*thisMol].c_str(),
+          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? 
+                  generatedSegmentNames[*thisMol].c_str() : 
+                  moleculeSegmentNames[*thisMol].c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -209,21 +209,27 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
   //silly psfs index from 1
   uint atomID = 1;
   uint resID = 1;
+  uint thisKIndex = 0, nAtoms = 0, sortedMolIndex = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    uint thisKind = molecules->kIndex[mol];
-    uint nAtoms = molKinds[thisKind].atoms.size();
+    if(enableSortedSegmentOut){
+      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
+      thisKIndex = molecules->kIndex[sortedMolIndex];
+    } else{
+      thisKIndex = molecules->kIndex[mol];
+    }
+    nAtoms = molKinds[thisKIndex].atoms.size();
 
     for(uint at = 0; at < nAtoms; ++at) {
-      const Atom* thisAtom = &molKinds[thisKind].atoms[at];
+      const Atom* thisAtom = &molKinds[thisKIndex].atoms[at];
       //atom ID, segment name, residue ID, residue name,
       //atom name, atom type, charge, mass, and an unused 0
 
-      if(molKinds[thisKind].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
-                  resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
+      if(molKinds[thisKIndex].isMultiResidue){
+          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
+                  resID + molKinds[thisKIndex].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }
@@ -234,8 +240,8 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
       molecule kinds we have printed */
     ++resID;
     /* To add additional intramolecular residues */
-    if (molKinds[thisKind].isMultiResidue){
-      resID += molKinds[thisKind].intraMoleculeResIDs.back();
+    if (molKinds[thisKIndex].isMultiResidue){
+      resID += molKinds[thisKIndex].intraMoleculeResIDs.back();
     }
 
    // ???
@@ -250,8 +256,15 @@ void PSFOutput::PrintBonds(FILE* outfile) const
   fprintf(outfile, headerFormat, totalBonds, bondHeader);
   uint atomID = 1;
   uint lineEntry = 0;
+  uint thisKIndex = 0, sortedMolIndex = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    const MolKind& thisKind = molKinds[molecules->kIndex[mol]];
+    if(enableSortedSegmentOut){
+      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
+      thisKIndex = molecules->kIndex[sortedMolIndex];
+    } else{
+      thisKIndex = molecules->kIndex[mol];
+    }
+    const MolKind& thisKind = molKinds[thisKIndex];
     for(uint i = 0; i < thisKind.bonds.size(); ++i) {
       fprintf(outfile, "%8d%8d", thisKind.bonds[i].a0 + atomID,
               thisKind.bonds[i].a1 + atomID);
@@ -271,8 +284,15 @@ void PSFOutput::PrintAngles(FILE* outfile) const
   fprintf(outfile, headerFormat, totalAngles, angleHeader);
   uint atomID = 1;
   uint lineEntry = 0;
+  uint thisKIndex = 0, sortedMolIndex = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    const MolKind& thisKind = molKinds[molecules->kIndex[mol]];
+    if(enableSortedSegmentOut){
+      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
+      thisKIndex = molecules->kIndex[sortedMolIndex];
+    } else{
+      thisKIndex = molecules->kIndex[mol];
+    }
+    const MolKind& thisKind = molKinds[thisKIndex];
     for(uint i = 0; i < thisKind.angles.size(); ++i) {
       fprintf(outfile, "%8d%8d%8d", thisKind.angles[i].a0 + atomID,
               thisKind.angles[i].a1 + atomID,
@@ -292,8 +312,15 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
   fprintf(outfile, headerFormat, totalDihs, dihedralHeader);
   uint atomID = 1;
   uint lineEntry = 0;
+  uint thisKIndex = 0, sortedMolIndex = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    const MolKind& thisKind = molKinds[molecules->kIndex[mol]];
+    if(enableSortedSegmentOut){
+      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
+      thisKIndex = molecules->kIndex[sortedMolIndex];
+    } else{
+      thisKIndex = molecules->kIndex[mol];
+    }
+    const MolKind& thisKind = molKinds[thisKIndex];
     for(uint i = 0; i < thisKind.dihedrals.size(); ++i) {
       fprintf(outfile, "%8d%8d%8d%8d", thisKind.dihedrals[i].a0 + atomID,
               thisKind.dihedrals[i].a1 + atomID,

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -38,8 +38,8 @@ PSFOutput::PSFOutput(const Molecules& molecules, const System &sys,
                      Setup & set) :
   molecules(&molecules), molLookRef(sys.molLookup),
   molNames(set.mol.molVars.moleculeKindNames), 
-  generateSegmentLabels(set.mol.molVars.generateSegmentLabels),
-  enableSortedSegmentOut (set.mol.molVars.sortBySegmentLabels),
+  enableGenerateSegmentOut(molecules.enableGenerateSegmentOut),
+  enableSortedSegmentOut(molecules.enableSortedSegmentOut),
   moleculeSegmentNames(set.mol.molVars.moleculeSegmentNames),
   generatedSegmentNames(set.mol.molVars.generatedSegmentNames)
 {
@@ -358,14 +358,14 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
         //atom name, atom type, charge, mass, and an unused 0
 
         if(molKinds[thisKind].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? 
+          fprintf(outfile, atomFormat, atomID, enableGenerateSegmentOut ? 
                   generatedSegmentNames[*thisMol].c_str() : 
                   moleculeSegmentNames[*thisMol].c_str(),
                   resID + molKinds[thisKind].intraMoleculeResIDs[at], 
                   thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? 
+          fprintf(outfile, atomFormat, atomID, enableGenerateSegmentOut ? 
                   generatedSegmentNames[*thisMol].c_str() : 
                   moleculeSegmentNames[*thisMol].c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -225,11 +225,11 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
       //atom name, atom type, charge, mass, and an unused 0
 
       if(molKinds[thisKIndex].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[sortedMolIndex].c_str() : moleculeSegmentNames[mol].c_str(),
                   resID + molKinds[thisKIndex].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[sortedMolIndex].c_str() : moleculeSegmentNames[mol].c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -37,7 +37,10 @@ const int dihPerLine = 2;
 PSFOutput::PSFOutput(const Molecules& molecules, const System &sys,
                      Setup & set) :
   molecules(&molecules), molLookRef(sys.molLookup),
-  molNames(set.mol.molVars.moleculeKindNames)
+  molNames(set.mol.molVars.moleculeKindNames), 
+  generateSegmentLabels(set.mol.molVars.generateSegmentLabels),
+  enableSortedSegmentOut (set.mol.molVars.sortBySegmentLabels),
+  moleculeSegmentNames(set.mol.molVars.moleculeSegmentNames)
 {
   molKinds.resize(set.mol.kindMap.size());
  for(uint i = 0; i < set.mol.molVars.moleculeKindNames.size(); ++i) {
@@ -216,24 +219,15 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
       //atom name, atom type, charge, mass, and an unused 0
 
       if(molKinds[thisKind].isMultiResidue){
-        fprintf(outfile, atomFormat, atomID, fixedOrder.uint2String(mol).c_str(),
-                resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
-                thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
-      } else {
-        fprintf(outfile, atomFormat, atomID, fixedOrder.uint2String(mol).c_str(),
-                resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
-                thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
-      }
-/*      if(molKinds[thisKind].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
                   resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[mol].c_str() : thisAtom->segment.c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }
-*/      
+      
       ++atomID;
     }
     /* This isn't actually residue, it is running count of the number of
@@ -352,11 +346,11 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
         //atom name, atom type, charge, mass, and an unused 0
 
         if(molKinds[thisKind].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[*thisMol].c_str() : thisAtom->segment.c_str(),
                   resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[*thisMol].c_str() : thisAtom->segment.c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -357,11 +357,11 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
         //atom name, atom type, charge, mass, and an unused 0
 
         if(molKinds[thisKind].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[*thisMol].c_str() : thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, moleculeSegmentNames[*thisMol].c_str(),
                   resID + molKinds[thisKind].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, generateSegmentLabels ? moleculeSegmentNames[*thisMol].c_str() : thisAtom->segment.c_str(),
+          fprintf(outfile, atomFormat, atomID, moleculeSegmentNames[*thisMol].c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }

--- a/src/PSFOutput.cpp
+++ b/src/PSFOutput.cpp
@@ -204,19 +204,15 @@ void PSFOutput::PrintRemarks(FILE* outfile, const std::vector<std::string>& rema
 
 void PSFOutput::PrintAtoms(FILE* outfile) const
 {
-  AlphaNum fixedOrder;
   fprintf(outfile, headerFormat, totalAtoms, atomHeader);
   //silly psfs index from 1
   uint atomID = 1;
   uint resID = 1;
-  uint thisKIndex = 0, nAtoms = 0, sortedMolIndex = 0;
+  uint thisKIndex = 0, nAtoms = 0, mI = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    if(enableSortedSegmentOut){
-      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
-      thisKIndex = molecules->kIndex[sortedMolIndex];
-    } else{
-      thisKIndex = molecules->kIndex[mol];
-    }
+    mI = enableSortedSegmentOut ? molecules->sortedMoleculeIndices[mol] : mol;
+    thisKIndex = molecules->kIndex[mI];
+    
     nAtoms = molKinds[thisKIndex].atoms.size();
 
     for(uint at = 0; at < nAtoms; ++at) {
@@ -225,11 +221,11 @@ void PSFOutput::PrintAtoms(FILE* outfile) const
       //atom name, atom type, charge, mass, and an unused 0
 
       if(molKinds[thisKIndex].isMultiResidue){
-          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[sortedMolIndex].c_str() : moleculeSegmentNames[mol].c_str(),
+          fprintf(outfile, atomFormat, atomID, moleculeSegmentNames[mI].c_str(),
                   resID + molKinds[thisKIndex].intraMoleculeResIDs[at], thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         } else {
-          fprintf(outfile, atomFormat, atomID, enableSortedSegmentOut ? moleculeSegmentNames[sortedMolIndex].c_str() : moleculeSegmentNames[mol].c_str(),
+          fprintf(outfile, atomFormat, atomID, moleculeSegmentNames[mI].c_str(),
                   resID, thisAtom->residue.c_str(), thisAtom->name.c_str(),
                   thisAtom->type.c_str(), thisAtom->charge, thisAtom->mass, 0);
         }
@@ -256,14 +252,10 @@ void PSFOutput::PrintBonds(FILE* outfile) const
   fprintf(outfile, headerFormat, totalBonds, bondHeader);
   uint atomID = 1;
   uint lineEntry = 0;
-  uint thisKIndex = 0, sortedMolIndex = 0;
+  uint thisKIndex = 0, mI = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    if(enableSortedSegmentOut){
-      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
-      thisKIndex = molecules->kIndex[sortedMolIndex];
-    } else{
-      thisKIndex = molecules->kIndex[mol];
-    }
+    mI = enableSortedSegmentOut ? molecules->sortedMoleculeIndices[mol] : mol;
+    thisKIndex = molecules->kIndex[mI];
     const MolKind& thisKind = molKinds[thisKIndex];
     for(uint i = 0; i < thisKind.bonds.size(); ++i) {
       fprintf(outfile, "%8d%8d", thisKind.bonds[i].a0 + atomID,
@@ -284,14 +276,10 @@ void PSFOutput::PrintAngles(FILE* outfile) const
   fprintf(outfile, headerFormat, totalAngles, angleHeader);
   uint atomID = 1;
   uint lineEntry = 0;
-  uint thisKIndex = 0, sortedMolIndex = 0;
+  uint thisKIndex = 0, mI = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    if(enableSortedSegmentOut){
-      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
-      thisKIndex = molecules->kIndex[sortedMolIndex];
-    } else{
-      thisKIndex = molecules->kIndex[mol];
-    }
+    mI = enableSortedSegmentOut ? molecules->sortedMoleculeIndices[mol] : mol;
+    thisKIndex = molecules->kIndex[mI];
     const MolKind& thisKind = molKinds[thisKIndex];
     for(uint i = 0; i < thisKind.angles.size(); ++i) {
       fprintf(outfile, "%8d%8d%8d", thisKind.angles[i].a0 + atomID,
@@ -312,14 +300,10 @@ void PSFOutput::PrintDihedrals(FILE* outfile) const
   fprintf(outfile, headerFormat, totalDihs, dihedralHeader);
   uint atomID = 1;
   uint lineEntry = 0;
-  uint thisKIndex = 0, sortedMolIndex = 0;
+  uint thisKIndex = 0, mI = 0;
   for(uint mol = 0; mol < molecules->count; ++mol) {
-    if(enableSortedSegmentOut){
-      sortedMolIndex = molecules->sortedMoleculeIndices[mol];
-      thisKIndex = molecules->kIndex[sortedMolIndex];
-    } else{
-      thisKIndex = molecules->kIndex[mol];
-    }
+    mI = enableSortedSegmentOut ? molecules->sortedMoleculeIndices[mol] : mol;
+    thisKIndex = molecules->kIndex[mI];
     const MolKind& thisKind = molKinds[thisKIndex];
     for(uint i = 0; i < thisKind.dihedrals.size(); ++i) {
       fprintf(outfile, "%8d%8d%8d%8d", thisKind.dihedrals[i].a0 + atomID,

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -68,11 +68,18 @@ private:
   void PrintAnglesInBox(FILE* outfile, uint b) const;
   void PrintDihedralsInBox(FILE* outfile, uint b) const;
 
+  void PrintAtomsInBox(FILE* outfile, uint b, std::vector<uint> & mBox) const;
+  void PrintBondsInBox(FILE* outfile, uint b, std::vector<uint> & mBox) const;
+  void PrintAnglesInBox(FILE* outfile, uint b, std::vector<uint> & mBox) const;
+  void PrintDihedralsInBox(FILE* outfile, uint b, std::vector<uint> & mBox) const;
+
   void PrintNAMDCompliantSuffix(FILE* outfile) const;
   void PrintNAMDCompliantSuffixInBox(FILE* outfile) const;
 
   void CountMolecules();
   void CountMoleculesInBoxes();
+
+  void SetMolBoxVec(std::vector<uint> & mBox);
 
   //NEW_RESTART_CODE
   FILE * outRebuildRestart[BOX_TOTAL];
@@ -84,6 +91,7 @@ private:
 
   /* For Hybrid MC-MD Order Consistency B/w cycles */
   std::vector<std::string> moleculeSegmentNames, generatedSegmentNames;
+  bool hybrid;
 };
 
 #endif

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -80,7 +80,10 @@ private:
   bool enableRestOut, enableRestIn;
   ulong stepsRestPerOut;
   //NEW_RESTART_CODE
-  bool enableOutState;
+  bool enableOutState, generateSegmentLabels, enableSortedSegmentOut;
+
+  /* For Hybrid MC-MD Order Consistency B/w cycles */
+  std::vector<std::string> moleculeSegmentNames;
 };
 
 #endif

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -80,7 +80,7 @@ private:
   bool enableRestOut, enableRestIn;
   ulong stepsRestPerOut;
   //NEW_RESTART_CODE
-  bool enableOutState, generateSegmentLabels, enableSortedSegmentOut;
+  bool enableOutState, enableGenerateSegmentOut, enableSortedSegmentOut;
 
   /* For Hybrid MC-MD Order Consistency B/w cycles */
   std::vector<std::string> moleculeSegmentNames, generatedSegmentNames;

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -16,6 +16,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "MoleculeLookup.h"
 #include "OutputAbstracts.h"
 #include "Writer.h"
+#include "AlphaNum.h"
 
 class Molecules;
 
@@ -76,7 +77,7 @@ private:
   //NEW_RESTART_CODE
   FILE * outRebuildRestart[BOX_TOTAL];
   std::string outRebuildRestartFName[BOX_TOTAL];
-  bool enableRestOut;
+  bool enableRestOut, enableRestIn;
   ulong stepsRestPerOut;
   //NEW_RESTART_CODE
   bool enableOutState;

--- a/src/PSFOutput.h
+++ b/src/PSFOutput.h
@@ -83,7 +83,7 @@ private:
   bool enableOutState, generateSegmentLabels, enableSortedSegmentOut;
 
   /* For Hybrid MC-MD Order Consistency B/w cycles */
-  std::vector<std::string> moleculeSegmentNames;
+  std::vector<std::string> moleculeSegmentNames, generatedSegmentNames;
 };
 
 #endif

--- a/src/Setup.h
+++ b/src/Setup.h
@@ -45,13 +45,6 @@ public:
       prngParallelTemp.Init(config.in.restart, config.in.prngParallelTempering, config.in.files.seed.name);
 #endif
     //Read molecule data from psf
-    /* GJS - I added pdb.atoms as an argument here, so I may modify the
-            pdb.atoms data structure to reflect multiresidue molecules.
-            Consolidating entries in startIDxRes will allow me to 
-            redefine the start and end of molecule.  Also, I generate a string
-            to serve as a multiresidue molecule entry into the kindMap containing
-            all these residues.  This is as upstream as possible to change as little code
-            as necessary */
     if(mol.Init(config.in.restart, config.in.files.psf.name, config.in.files.psf.defined, pdb.atoms) != 0) {
       exit(EXIT_FAILURE);
     }

--- a/src/Setup.h
+++ b/src/Setup.h
@@ -45,7 +45,7 @@ public:
       prngParallelTemp.Init(config.in.restart, config.in.prngParallelTempering, config.in.files.seed.name);
 #endif
     //Read molecule data from psf
-    if(mol.Init(config.in.restart, config.in.files.psf.name, config.in.files.psf.defined, pdb.atoms) != 0) {
+    if(mol.Init(config.in.restart.enable, config.out.restart.settings.enable, config.in.files.psf.name, config.in.files.psf.defined, pdb.atoms) != 0) {
       exit(EXIT_FAILURE);
     }
     mol.AssignKinds(mol.molVars, ff);


### PR DESCRIPTION
**Usage:** No different from current usage.  Just pay attention to accurately set "Restart true" and "RestartFreq true 123"
________________________________________________________________________________________________

**This PR will ensure that trajectory files (PDB/DCD) have the same order across restarts.**  Prior behavior was to sort by the box and kinds (Box 0, Kind 0, Box 0 Kind 1, Box 1 Kind 0, Box 1 Kind 1) at the beginning of a simulation.  However, when restarting a simulation, the original run's trajectory would be permuted compared to the restart's trajectory, preventing concatenation.

This PR generates up to ( 26^4 + 26^3 + 26^2 + 26 ) alphabetical keys for each molecule upon initial run if the user specifies he wants to produce restart outputs.  **It is important not to set "Restart true" on the first run, since this flag prevents these keys from being generated.**

**There is no way to prevent sorting if "Restart true" is set, but there is also no way to prevent key generation if "RestartFreq true" is set.**  Sorting all the molecules once per simulation doesn't seem to be a large performance cost, and we need the consistency to **track single molecules across restarts for diffusion calculations.**

Diffusion calculations will need to account for molecule transfers, which will result in a molecule instantaneously assuming a coordinate of {0.0, 0.0, 0.0}.  This is because we have different trajectory files for each box.  Perhaps we could create a single trajectory file, since beta is output in the PDB Trajectory.  This can be considered in future PR's.

**Importantly, the keys are only printed in the restart psf files initially, so the first (*_merged.psf) retains original segment data if the user wants to conduct analysis based off segment.**

Then, the next simulation, if "Restart true" is set, will generate a vector of indices which allow for outputting in sorted order.  **No underlying changes were made to how the molecules are represented during the simulation**, ensuring compatability with Binary checkpoint restoring the MolLookup data.

Concerns for backwards compatability: We will now sort the output by segment data on restarts.  This won't affect the validity of any calculations, however, outputs would be in a different order if you continued an old GOMC simulation.

**GTesting:  I will write some GTests, but I currently have another branch with a much more developed GTesting setup, and I will wait until I merge that branch.**

Files Attached: Original_merged.psf, Restarted_merged.psf (Same except for segment labels in Restarted_merged.psf)
![Orig_merged_psf_vs_Restart_merged_psf](https://user-images.githubusercontent.com/39970712/114242472-f1554080-9958-11eb-8d4f-366d937a4b7a.png)

                         Original_BOX_0.pdb, Restarted_BOX_0.pdb (Same except for coordinates)
![Orig_BOX_0_vs_Restart_BOX_0](https://user-images.githubusercontent.com/39970712/114242490-f7e3b800-9958-11eb-803a-0ee77d316f52.png)

                         Original_BOX_1.pdb, Restarted_BOX_1.pdb (Same except for coordinates)
![Orig_BOX_1_vs_Restart_BOX_1](https://user-images.githubusercontent.com/39970712/114242499-fd410280-9958-11eb-9dec-c5a9596406fb.png)

                         ./inputs (To be run in GEMC)
[files.tar.gz](https://github.com/GOMC-WSU/GOMC/files/6288590/files.tar.gz)


