### PR TITLE
Reading, updating, and outputting binary Velocity file

### DIFF
--- a/CMake/FileLists.cmake
+++ b/CMake/FileLists.cmake
@@ -142,6 +142,7 @@ set(headers
    src/SubdividedArray.h
    src/System.h
    src/TransformMatrix.h
+   src/Velocity.h
    src/Writer.h
    src/XYZArray.h
    src/cbmc/DCComponent.h

--- a/CMake/FileLists.cmake
+++ b/CMake/FileLists.cmake
@@ -13,7 +13,7 @@ set(sources
    src/CheckpointOutput.cpp
    src/CheckpointSetup.cpp
    src/DCDlib.cpp
-   src/DCDOutput.cpp
+   src/ExtendedSystemOutput.cpp
    src/EnPartCntSampleOutput.cpp
    src/ExtendedSystem.cpp
    src/Ewald.cpp
@@ -85,7 +85,7 @@ set(headers
    src/CoordinateSetup.h
    src/CPUSide.h
    src/DCDlib.h
-   src/DCDOutput.h
+   src/ExtendedSystemOutput.h
    src/EnergyTypes.h
    src/EnPartCntSampleOutput.h
    src/EnsemblePreprocessor.h

--- a/src/CPUSide.cpp
+++ b/src/CPUSide.cpp
@@ -13,7 +13,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 CPUSide::CPUSide(System & sys, StaticVals & statV, Setup & set) :
   varRef(sys, statV, set.mol.molVars.moleculeKindNames), pdb(sys, statV), 
   psf(statV.mol, sys, set), 
-  dcd(sys, statV),
+  xstBinary(sys, statV),
   console(varRef), block(varRef),
   hist(varRef), checkpoint(sys, statV)
 #if ENSEMBLE == GCMC
@@ -37,7 +37,7 @@ void CPUSide::Init( PDBSetup const& pdbSet,
   timer.Init(out.console.frequency, totSteps, startStep);
   outObj.push_back(&console);
   outObj.push_back(&pdb);
-  outObj.push_back(&dcd);
+  outObj.push_back(&xstBinary);
   outObj.push_back(&psf);
   if (out.statistics.settings.block.enable)
     outObj.push_back(&block);

--- a/src/CPUSide.h
+++ b/src/CPUSide.h
@@ -11,7 +11,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "Clock.h"
 #include "ConsoleOutput.h"
 #include "PDBOutput.h"
-#include "DCDOutput.h"
+#include "ExtendedSystemOutput.h"
 #include "BlockOutput.h"
 #include "HistOutput.h"
 #include "ConfigSetup.h"
@@ -43,7 +43,7 @@ private:
   OutputVars varRef;
   PDBOutput pdb;
   PSFOutput psf;
-  DCDOutput dcd;
+  ExtendedSystemOutput xstBinary;
   ConsoleOutput console;
   BlockAverages block;
   Histogram hist;

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -22,7 +22,8 @@ ConfigSetup::ConfigSetup(void)
   in.restart.step = ULONG_MAX;
   in.restart.recalcTrajectory = false;
   in.restart.restartFromCheckpoint = false;
-  in.restart.restartFromBinaryFile = false;
+  in.restart.restartFromBinaryCoorFile = false;
+  in.restart.restartFromBinaryVelFile = false;
   in.restart.restartFromXSCFile = false;
   in.prng.seed = UINT_MAX;
   in.prngParallelTempering.seed = UINT_MAX;
@@ -52,7 +53,8 @@ ConfigSetup::ConfigSetup(void)
   for(i = 0; i < BOX_TOTAL; i++) {
     in.files.pdb.name[i] = "";
     in.files.psf.name[i] = "";
-    in.files.binaryInput.name[i] = "";
+    in.files.binaryCoorInput.name[i] = "";
+    in.files.binaryVelInput.name[i] = "";
     in.files.xscInput.name[i] = "";
   }
 #if ENSEMBLE == GEMC
@@ -83,6 +85,7 @@ ConfigSetup::ConfigSetup(void)
   out.state.settings.enable = false;
   out.restart.settings.enable = false;
   out.state_dcd.settings.enable = false;
+  out.restart_vel.settings.enable = false;
   out.console.enable = true;
   out.statistics.settings.block.enable = true;
 #if ENSEMBLE == GCMC
@@ -268,12 +271,28 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
         exit(EXIT_FAILURE);
       }
       if (multisim != NULL) {
-        in.files.binaryInput.name[boxnum] = multisim->replicaInputDirectoryPath + line[2];
+        in.files.binaryCoorInput.name[boxnum] = multisim->replicaInputDirectoryPath + line[2];
       } else {
-        in.files.binaryInput.name[boxnum] = line[2];
+        in.files.binaryCoorInput.name[boxnum] = line[2];
       }
-      in.files.binaryInput.defined[boxnum] = true;
-      in.restart.restartFromBinaryFile = true;
+      in.files.binaryCoorInput.defined[boxnum] = true;
+      in.restart.restartFromBinaryCoorFile = true;
+    } else if(CheckString(line[0], "binVelocities")) {
+      uint boxnum = stringtoi(line[1]);
+      if(boxnum >= BOX_TOTAL) {
+        std::cout << "Error: Simulation requires " << BOX_TOTAL << " binary velocity file(s)!\n";
+        exit(EXIT_FAILURE);
+      }
+      if (multisim != NULL) {
+        in.files.binaryVelInput.name[boxnum] = multisim->replicaInputDirectoryPath + line[2];
+      } else {
+        in.files.binaryVelInput.name[boxnum] = line[2];
+      }
+      in.files.binaryVelInput.defined[boxnum] = true;
+      in.restart.restartFromBinaryVelFile = true;
+      // If we read the binary vel, we also output the restart vel. Otherwise
+      // we dont have any output velocity
+      out.restart_vel.settings.enable = true;
     } else if(CheckString(line[0], "extendedSystem")) {
       uint boxnum = stringtoi(line[1]);
       if(boxnum >= BOX_TOTAL) {
@@ -1504,6 +1523,8 @@ void ConfigSetup::fillDefaults(void)
                                   "_BOX_" + numStr + ".dcd";
     out.restart_dcd.files.dcd.name[i] = out.statistics.settings.uniqueStr.val +
                                   "_BOX_" + numStr + "_restart.coor";
+    out.restart_vel.files.dcd.name[i] = out.statistics.settings.uniqueStr.val +
+                                  "_BOX_" + numStr + "_restart.vel";
     out.state.files.splitPSF.name[i] = out.statistics.settings.uniqueStr.val +
                                   "_BOX_" + numStr + ".psf";                              
   }
@@ -1740,9 +1761,9 @@ void ConfigSetup::verifyInputs(void)
 
   if(in.restart.enable) {
     // error checking to see if if we missed any binary coordinate file
-    if(in.restart.restartFromBinaryFile) {
+    if(in.restart.restartFromBinaryCoorFile) {
       for(i = 0 ; i < BOX_TOTAL ; i++) {
-        if(!in.files.binaryInput.defined[i]) {
+        if(!in.files.binaryCoorInput.defined[i]) {
           std::cout << "Error: Binary coordinate file is not specified for box number " <<
                     i << "!" << std::endl;  
           exit(EXIT_FAILURE);

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -2087,14 +2087,30 @@ void ConfigSetup::verifyInputs(void)
   if(out.state.settings.enable && out.restart.settings.enable) {
     if(out.state.settings.frequency < out.restart.settings.frequency) {
       if ((out.restart.settings.frequency % out.state.settings.frequency) != 0) {
-        std::cout << "Error: Coordinate frequency must be common multiple of ";
+        std::cout << "Error: Coordinate frequency must be common multiple of \n";
         std::cout << "       restart corrdinate frequency !\n";
         exit(EXIT_FAILURE);
       }
     } else {
       if ((out.state.settings.frequency % out.restart.settings.frequency) != 0) {
-        std::cout << "Error: Restart coordinate frequency must be common multiple of ";
+        std::cout << "Error: Restart coordinate frequency must be common multiple of \n";
         std::cout << "       corrdinate frequency !\n";
+        exit(EXIT_FAILURE);
+      }
+    }
+  }
+
+  if(out.state_dcd.settings.enable && out.restart.settings.enable) {
+    if(out.state_dcd.settings.frequency < out.restart.settings.frequency) {
+      if ((out.restart.settings.frequency % out.state_dcd.settings.frequency) != 0) {
+        std::cout << "Error: DCD frequency must be common multiple of \n";
+        std::cout << "       restart corrdinate frequency !\n";
+        exit(EXIT_FAILURE);
+      }
+    } else {
+      if ((out.state_dcd.settings.frequency % out.restart.settings.frequency) != 0) {
+        std::cout << "Error: Restart coordinate frequency must be common multiple of \n";
+        std::cout << "       DCD frequency !\n";
         exit(EXIT_FAILURE);
       }
     }

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -75,7 +75,8 @@ struct RestartSettings {
   ulong step;
   bool recalcTrajectory;
   bool restartFromCheckpoint;
-  bool restartFromBinaryFile;
+  bool restartFromBinaryCoorFile;
+  bool restartFromBinaryVelFile;
   bool restartFromXSCFile;
   bool operator()(void)
   {
@@ -111,7 +112,8 @@ struct FFKind {
 //Files for input.
 struct InFiles {
   std::vector<FileName> param;
-  FileNames<BOX_TOTAL> pdb, psf, binaryInput, xscInput, checkpoint;
+  FileNames<BOX_TOTAL> pdb, psf, checkpoint;
+  FileNames<BOX_TOTAL> binaryCoorInput, binaryVelInput, xscInput;
   FileName seed;
 };
 
@@ -875,6 +877,7 @@ struct Statistics {
 };
 struct Output {
   SysState state, restart, state_dcd, restart_dcd;
+  SysState restart_vel;
   Statistics statistics;
   EventSettings console, checkpoint;
 };

--- a/src/ExtendedSystem.h
+++ b/src/ExtendedSystem.h
@@ -14,6 +14,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "PDBSetup.h"
 #include "Molecules.h"
 #include "MoleculeLookup.h"
+#include "Velocity.h"
 #include "GeomLib.h" // for PI and Dot product
 #include <vector>
 
@@ -34,14 +35,19 @@ class ExtendedSystem  {
   public:
   ExtendedSystem();
   ~ExtendedSystem() {};
-  void Init(PDBSetup &pdb, config_setup::Input inputFiles, MoleculeLookup & molLookup, Molecules & mols);
+  void Init(PDBSetup &pdb, Velocity &vel, config_setup::Input inputFiles,
+            MoleculeLookup & molLookup, Molecules & mols);
   private:
     // Reads the xsc file and store/calculate cellBasis data
     void ReadExtendedSystem(const char *filename, const int box);
     // Updates the cellBasis data in pdb data structure
     void UpdateCellBasis(PDBSetup &pdb, const int box);
     // Reads the binary coordinates and updates the X Y Z coordinates in pdb data structure
-    void UpdateCoordinate(PDBSetup &pdb, const char *filename, const int box, MoleculeLookup & molLookup, Molecules & mols, int & cmIndex);
+    void UpdateCoordinate(PDBSetup &pdb, const char *filename, const int box,
+                          MoleculeLookup & molLookup, Molecules & mols, int & cmIndex);
+    // Reads the binary velocities and updates the X Y Z velocity data structure
+    void UpdateVelocity(PDBSetup &pdb, Velocity &vel, const char *filename, const int box,
+                        MoleculeLookup & molLookup, Molecules & mols, int & cmIndex);
     // the time steps in xsc file
     ulong firstStep;
     // Center of cell, but GOMC always uses 0 center

--- a/src/ExtendedSystemOutput.cpp
+++ b/src/ExtendedSystemOutput.cpp
@@ -4,7 +4,7 @@ Copyright (C) 2018  GOMC Group
 A copy of the GNU General Public License can be found in the COPYRIGHT.txt
 along with this program, also can be found at <http://www.gnu.org/licenses/>.
 ********************************************************************************/
-#include "DCDOutput.h"              //For spec;
+#include "ExtendedSystemOutput.h"              //For spec;
 #include "EnsemblePreprocessor.h"   //For BOX_TOTAL, ensemble
 #include "System.h"                 //for init
 #include "StaticVals.h"             //for init
@@ -15,7 +15,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "StrStrmLib.h"             //For conversion from uint to string
 #include <iostream>                 //for cout;
 
-DCDOutput::DCDOutput(System& sys, StaticVals const& statV) :
+ExtendedSystemOutput::ExtendedSystemOutput(System& sys, StaticVals const& statV) :
   moveSetRef(sys.moveSettings), molLookupRef(sys.molLookupRef),
   boxDimRef(sys.boxDimRef), molRef(statV.mol),
   coordCurrRef(sys.coordinates), comCurrRef(sys.com)
@@ -34,7 +34,7 @@ DCDOutput::DCDOutput(System& sys, StaticVals const& statV) :
   }
 }
 
-void DCDOutput::Init(pdb_setup::Atoms const& atoms,
+void ExtendedSystemOutput::Init(pdb_setup::Atoms const& atoms,
                      config_setup::Output const& output)
 {
   enableStateOut = output.state_dcd.settings.enable;
@@ -101,7 +101,7 @@ void DCDOutput::Init(pdb_setup::Atoms const& atoms,
 }
 
 
-void DCDOutput::Write_Extension_System_Header(Writer &outFile)
+void ExtendedSystemOutput::Write_Extension_System_Header(Writer &outFile)
 {
   outFile.file << "#$LABELS step";
   outFile.file << " a_x a_y a_z";
@@ -112,7 +112,7 @@ void DCDOutput::Write_Extension_System_Header(Writer &outFile)
 }
 
 
-void DCDOutput::Write_Extension_System_Data(Writer &outFile,
+void ExtendedSystemOutput::Write_Extension_System_Data(Writer &outFile,
     const ulong step, const int box)
 {
   outFile.file.precision(12);
@@ -143,7 +143,7 @@ void DCDOutput::Write_Extension_System_Data(Writer &outFile,
   outFile.file << std::endl;
 }
 
-void DCDOutput::WriteDCDHeader(const int numAtoms, const int box)
+void ExtendedSystemOutput::WriteDCDHeader(const int numAtoms, const int box)
 {
   printf("Opening DCD coordinate file: %s \n", outDCDStateFile[box]);
   stateFileFileid[box] = open_dcd_write(outDCDStateFile[box]);
@@ -176,10 +176,10 @@ void DCDOutput::WriteDCDHeader(const int numAtoms, const int box)
   }
 }
 
-void DCDOutput::DoOutput(const ulong step)
+void ExtendedSystemOutput::DoOutput(const ulong step)
 {
   // Output dcd coordinates and xst file
-  if(enableStateOut) {
+  if(((step + 1) % stepsStatePerOut == 0) && enableStateOut) {
     GOMC_EVENT_START(1, GomcProfileEvent::DCD_OUTPUT);
     int numAtoms = coordCurrRef.Count();
     // Determine which molecule is in which box. Assume we are in NVT
@@ -240,7 +240,7 @@ void DCDOutput::DoOutput(const ulong step)
 
 }
 
-int DCDOutput::NumAtomInBox(const int box)
+int ExtendedSystemOutput::NumAtomInBox(const int box)
 {
   int numAtoms = 0;
   int totKind = molLookupRef.GetNumKind();
@@ -251,7 +251,7 @@ int DCDOutput::NumAtomInBox(const int box)
   return numAtoms;
 }
 
-void DCDOutput::SetMolInBox(const int box)
+void ExtendedSystemOutput::SetMolInBox(const int box)
 {
   #if ENSEMBLE == GCMC || ENSEMBLE == GEMC      
   if(restartCoor[box]) {
@@ -280,7 +280,7 @@ void DCDOutput::SetMolInBox(const int box)
   }
 }
 
-void DCDOutput::Write_binary_file(char *fname, int n, XYZ *vec) 
+void ExtendedSystemOutput::Write_binary_file(char *fname, int n, XYZ *vec) 
 {
   char errmsg[256];
   int fd;    //  File descriptor
@@ -298,7 +298,7 @@ void DCDOutput::Write_binary_file(char *fname, int n, XYZ *vec)
 
 }
 
-void DCDOutput::SetCoordinates(std::vector<int> &molInBox, const int box)
+void ExtendedSystemOutput::SetCoordinates(std::vector<int> &molInBox, const int box)
 {
   uint p, pStart = 0, pEnd = 0;
   int numMolecules = molRef.count;
@@ -341,7 +341,7 @@ void DCDOutput::SetCoordinates(std::vector<int> &molInBox, const int box)
 
 }
 
-void DCDOutput::Copy_lattice_to_unitcell(double *unitcell, int box) {
+void ExtendedSystemOutput::Copy_lattice_to_unitcell(double *unitcell, int box) {
   unitcell[0] = boxDimRef.GetAxis(box).x;
   unitcell[2] = boxDimRef.GetAxis(box).y;
   unitcell[5] = boxDimRef.GetAxis(box).z;
@@ -351,7 +351,7 @@ void DCDOutput::Copy_lattice_to_unitcell(double *unitcell, int box) {
 }
 
 
-void DCDOutput::SetMolBoxVec(std::vector<int> & mBox)
+void ExtendedSystemOutput::SetMolBoxVec(std::vector<int> & mBox)
 {
   for (int b = 0; b < BOX_TOTAL; ++b) {
     MoleculeLookup::box_iterator m = molLookupRef.BoxBegin(b),

--- a/src/ExtendedSystemOutput.h
+++ b/src/ExtendedSystemOutput.h
@@ -31,11 +31,11 @@ struct Output;
 class MoveSettings;
 class MoleculeLookup;
 
-struct DCDOutput : OutputableBase {
+struct ExtendedSystemOutput : OutputableBase {
 public:
-  DCDOutput(System & sys, StaticVals const& statV);
+  ExtendedSystemOutput(System & sys, StaticVals const& statV);
 
-  ~DCDOutput()
+  ~ExtendedSystemOutput()
   {
     if (x) {
       delete [] x; // y and z are continue of x

--- a/src/ExtendedSystemOutput.h
+++ b/src/ExtendedSystemOutput.h
@@ -19,6 +19,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "MoleculeKind.h"
 #include "StaticVals.h"
 #include "Coordinates.h"
+#include "Velocity.h"
 #include "Writer.h"
 #include "DCDlib.h"
 #include "PDBSetup.h" //For atoms class
@@ -48,11 +49,17 @@ public:
       if(restartCoor[b]) {
         delete [] restartCoor[b];
       }
+      if(restartVel[b]) {
+        delete [] restartVel[b];
+      }
       if(outDCDStateFile[b]) {
         delete [] outDCDStateFile[b];
       }
       if(outDCDRestartFile[b]) {
         delete [] outDCDRestartFile[b];
+      }
+      if(outVelRestartFile[b]) {
+        delete [] outVelRestartFile[b];
       }
       if (outXSTFile[b]) {
         delete [] outXSTFile[b];
@@ -76,6 +83,7 @@ private:
   // Unwrap and save coordinates of molecule in box, into *x, *y, *z
   void SetCoordinates(std::vector<int> &molInBox, const int box);
   // Unwrap and save coordinates of molecule in box, into *restartCoor
+  // Save velocities of molecule in box, into *restartVel
   void SetMolInBox(const int box);
   // Return a vector that defines the box id for each molecule
   void SetMolBoxVec(std::vector<int> & mBox);
@@ -96,20 +104,24 @@ private:
   BoxDimensions& boxDimRef;
   Molecules const& molRef;
   Coordinates & coordCurrRef;
+  Velocity & velCurrRef;
   COM & comCurrRef;
 
   char *outDCDStateFile[BOX_TOTAL];
   char *outDCDRestartFile[BOX_TOTAL];
+  char *outVelRestartFile[BOX_TOTAL];
   char *outXSTFile[BOX_TOTAL];
   char *outXSCFile[BOX_TOTAL];
   int stateFileFileid[BOX_TOTAL];
   bool enableRestartOut, enableStateOut;
+  bool outputVelocity; //output Velocity or not
   ulong stepsRestartPerOut, stepsStatePerOut;
   // 
   float *x, *y, *z;
   // AOS for restart binary format. NAMD internal data structure 
   // is array of vector(XYZ)
   XYZ *restartCoor[BOX_TOTAL]; 
+  XYZ *restartVel[BOX_TOTAL]; 
   // for extension system files
   Writer xstFile[BOX_TOTAL];
   Writer xscFile[BOX_TOTAL];

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -45,9 +45,9 @@ void PDBOutput::Init(pdb_setup::Atoms const& atoms,
   stepsCoordPerOut = output.state.settings.frequency;
   stepsRestPerOut = output.restart.settings.frequency;
   if (stepsCoordPerOut < stepsRestPerOut)
-    stepsPerOut = output.state.settings.frequency;
+    stepsPerOut = stepsCoordPerOut;
   else
-    stepsPerOut = output.restart.settings.frequency;
+    stepsPerOut = stepsRestPerOut;
 
   if (enableOutState) {
     for (uint b = 0; b < BOX_TOTAL; ++b) {
@@ -162,7 +162,7 @@ void PDBOutput::FormatAtom
 
 void PDBOutput::DoOutput(const ulong step)
 {
-  if(enableOutState) {
+  if(enableOutState && ((step + 1) % stepsCoordPerOut == 0)) {
     GOMC_EVENT_START(1, GomcProfileEvent::PDB_OUTPUT);
     std::vector<uint> mBox(molRef.count);
     SetMolBoxVec(mBox);

--- a/src/PDBSetup.cpp
+++ b/src/PDBSetup.cpp
@@ -30,7 +30,7 @@ void Remarks::SetRestart(config_setup::RestartSettings const& r )
   restart = r.enable;
   recalcTrajectory = r.recalcTrajectory;
   restartFromXSC = r.restartFromXSCFile;
-  restartFromBinary = r.restartFromBinaryFile;
+  restartFromBinary = r.restartFromBinaryCoorFile;
 
   for(uint b = 0; b < BOX_TOTAL; b++) {
     if(recalcTrajectory)

--- a/src/System.h
+++ b/src/System.h
@@ -27,6 +27,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "CheckpointSetup.h"
 #include "../lib/Lambda.h"
 #include "Random123Wrapper.h"
+#include "Velocity.h"
 
 //Initialization variables
 class Setup;
@@ -109,6 +110,7 @@ public:
   Lambda lambdaRef;
   COM com;
   ExtendedSystem xsc;
+  Velocity vel;
 
   CalculateEnergy calcEnergy;
   Ewald *calcEwald;

--- a/src/UnitConst.h
+++ b/src/UnitConst.h
@@ -10,6 +10,8 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 //Constants for unit conversion
 namespace unit
 {
+// Boltzmann constant
+static const double BOLTZMANN = 0.001987191;
 
 // Molecules: molecules/A3 --> mol/cm3
 //

--- a/src/Velocity.h
+++ b/src/Velocity.h
@@ -1,0 +1,157 @@
+/*******************************************************************************
+GPU OPTIMIZED MONTE CARLO (GOMC) 2.70
+Copyright (C) 2018  GOMC Group
+A copy of the GNU General Public License can be found in the COPYRIGHT.txt
+along with this program, also can be found at <http://www.gnu.org/licenses/>.
+********************************************************************************/
+#ifndef VELOCITY_H
+#define VELOCITY_H
+
+#include "Forcefield.h"
+#include "XYZArray.h"
+#include "Molecules.h"
+#include "MoleculeLookup.h"
+#include "PDBSetup.h"
+#include "ConfigSetup.h"
+#include "PRNG.h"
+
+namespace config_setup
+{
+  struct Input;
+}
+
+class Velocity : public XYZArray
+{
+public:
+    Velocity(Forcefield &ff, MoleculeLookup & molLook, Molecules const& mol, PRNG & prng) :
+    prngRef(prng), molRef(mol), molLookRef(molLook), temperature(ff.T_in_K),
+    hasVelocity(false) {}
+
+    void Init(pdb_setup::Atoms const& atoms, config_setup::Input const& inputFile) {
+        if(inputFile.restart.restartFromBinaryVelFile){
+            hasVelocity = true;
+            //Allocate master array
+            XYZArray::Init(atoms.beta.size());
+            for(int b = 0; b < BOX_TOTAL; ++b) {
+                updateBoxVelocity[b] = false;
+            }
+        } else {
+            hasVelocity = false;
+        }
+        // We dont set the velocity values. We read it from restart
+        // binary velocity outputted by MD simulation
+    }
+
+    void UpdateBoxVelocity(const uint &box) {
+        updateBoxVelocity[box] = true;
+    }
+
+    void UpdateMolVelocity(const uint &mol, const uint &box) {
+        // Do not do anything if we did not read velocity
+        // If we performed a move that requires to update all atom's
+        // velocity, we do not waste time and return
+        if(!hasVelocity || updateBoxVelocity[box]) {
+            return;
+        }
+
+        molRef.GetRangeStartStop(pStart, pEnd, mol);
+        for (int p = pStart; p < pEnd; ++p) {
+            mass = molRef.GetKind(mol).atomMass[p - pStart];
+            this->Set(p, Random_velocity(mass));
+        }
+    }
+
+    void UpdateVelocityInBox(const int box) {
+        // Do not do anything if we did not read velocity
+        // If we Did not performed a move that requires to update all atom's
+        // velocity, we should not update the velocity
+        if(!updateBoxVelocity[box] || !hasVelocity) {
+            return;
+        }
+
+        MoleculeLookup::box_iterator m = molLookRef.BoxBegin(box),
+                                    end = molLookRef.BoxEnd(box);
+        // loop thorugh all molecule in box
+        while (m != end) {
+            molRef.GetRangeStartStop(pStart, pEnd, *m);
+            for (p = pStart; p < pEnd; ++p) {
+                mass = molRef.GetKind(*m).atomMass[p - pStart];
+                this->Set(p, Random_velocity(mass));
+            }
+            ++m;
+        }
+    }
+
+    Velocity& operator=(Velocity const& rhs)
+    {
+        this->XYZArray::operator=(rhs);
+        for(int b = 0; b < BOX_TOTAL; ++b) {
+            updateBoxVelocity[b] = rhs.updateBoxVelocity[b];
+        }
+        temperature = rhs.temperature;
+        return *this;
+    }
+
+private:
+
+    //  The following comment was taken from X-PLOR where
+    //  the following section of code was adapted from.
+    //  NAMD uses same function
+    //  This section generates a Gaussian random
+    //  deviate of 0.0 mean and standard deviation RFD for
+    //  each of the three spatial dimensions.
+    //  The algorithm is a "sum of uniform deviates algorithm"
+    //  which may be found in Abramowitz and Stegun,
+    //  "Handbook of Mathematical Functions", pg 952.
+    XYZ Random_velocity(const double &mass) {
+        XYZ vel;
+        if(mass <= 0.0) {
+            kbToverM = 0.0;
+        }else {
+            kbToverM = sqrt(temperature / mass);
+        }
+
+        for(randnum=0.0, i=0; i<12; ++i)
+        {
+            randnum += prngRef();
+        }
+
+        randnum -= 6.0;
+        vel.x = randnum*kbToverM;
+
+        for(randnum=0.0, i=0; i<12; ++i)
+        {
+            randnum += prngRef();
+        }
+
+        randnum -= 6.0;
+        vel.y = randnum*kbToverM;
+
+        for(randnum=0.0, i=0; i<12; ++i)
+        {
+            randnum += prngRef();
+        }
+
+        randnum -= 6.0;
+        vel.z = randnum*kbToverM;
+
+        return vel;
+    }
+
+    PRNG& prngRef;
+    Molecules const& molRef;
+    MoleculeLookup & molLookRef;
+    uint pStart, pEnd;  // start and end of atom index
+    int p, i;           // Iterator
+    double randnum;	    // Random number from -6.0 to 6.0
+    double kbToverM;	// sqrt(Kb*Temp/Mass)
+    double mass;        // Mass of particle
+
+    bool hasVelocity;
+    bool updateBoxVelocity[BOX_TOTAL];     // update all atom's velocities
+    double & temperature;                  // system temperature
+
+};
+
+
+#endif

--- a/src/Velocity.h
+++ b/src/Velocity.h
@@ -14,6 +14,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "PDBSetup.h"
 #include "ConfigSetup.h"
 #include "PRNG.h"
+#include "UnitConst.h"
 
 namespace config_setup
 {
@@ -108,7 +109,7 @@ private:
         if(mass <= 0.0) {
             kbToverM = 0.0;
         }else {
-            kbToverM = sqrt(temperature / mass);
+            kbToverM = sqrt(temperature * unit::BOLTZMANN / mass);
         }
 
         for(randnum=0.0, i=0; i<12; ++i)

--- a/src/moves/CrankShaft.h
+++ b/src/moves/CrankShaft.h
@@ -168,6 +168,8 @@ inline void CrankShaft::Accept(const uint rejectState, const uint step)
 
       //Retotal
       sysPotRef.Total();
+      // Update the velocity
+      velocity.UpdateMolVelocity(molIndex, sourceBox);
     } else {
       cellList.AddMol(molIndex, sourceBox, coordCurrRef);
 

--- a/src/moves/IntraMoleculeExchange1.h
+++ b/src/moves/IntraMoleculeExchange1.h
@@ -596,6 +596,15 @@ inline void IntraMoleculeExchange1::Accept(const uint rejectState,
 
       // Recalculate total
       sysPotRef.Total();
+
+      // Update the velocity
+      for(uint n = 0; n < numInCavB; n++) {
+        velocity.UpdateMolVelocity(molIndexB[n], sourceBox);
+      }
+      for(uint n = 0; n < numInCavA; n++) {
+        velocity.UpdateMolVelocity(molIndexA[n], sourceBox);
+      }
+
     } else {
       //transfer molA
       for(uint n = 0; n < numInCavA; n++) {

--- a/src/moves/IntraSwap.h
+++ b/src/moves/IntraSwap.h
@@ -169,6 +169,8 @@ inline void IntraSwap::Accept(const uint rejectState, const uint step)
 
       //Retotal
       sysPotRef.Total();
+      // Update the velocity
+      velocity.UpdateMolVelocity(molIndex, sourceBox);
     } else {
       cellList.AddMol(molIndex, sourceBox, coordCurrRef);
 

--- a/src/moves/MoleculeExchange1.h
+++ b/src/moves/MoleculeExchange1.h
@@ -774,6 +774,15 @@ inline void MoleculeExchange1::Accept(const uint rejectState, const uint step)
       //molA and molB already transferred to destBox and added to cellist
       //Retotal
       sysPotRef.Total();
+
+      // Update the velocity
+      for(uint n = 0; n < numInCavB; n++) {
+        velocity.UpdateMolVelocity(molIndexB[n], sourceBox);
+      }
+      for(uint n = 0; n < numInCavA; n++) {
+        velocity.UpdateMolVelocity(molIndexA[n], destBox);
+      }
+
     } else {
       //transfer molA from destBox to source
       for(uint n = 0; n < numInCavA; n++) {

--- a/src/moves/MoleculeTransfer.h
+++ b/src/moves/MoleculeTransfer.h
@@ -228,6 +228,8 @@ inline void MoleculeTransfer::Accept(const uint rejectState, const uint step)
 
       //Retotal
       sysPotRef.Total();
+      // Update the velocity
+      velocity.UpdateMolVelocity(molIndex, destBox);
     } else {
       cellList.AddMol(molIndex, sourceBox, coordCurrRef);
       //when weight is 0, MolDestSwap() will not be executed, thus cos/sin

--- a/src/moves/MoveBase.h
+++ b/src/moves/MoveBase.h
@@ -26,6 +26,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #include "MolPick.h"
 #include "Forcefield.h"
 #include "GOMCEventsProfile.h" // for NVTX profiling
+#include "Velocity.h"
 
 class MoveBase
 {
@@ -39,7 +40,7 @@ public:
     molForceRecRef(sys.molForceRecRef), prng(sys.prng),
     boxDimRef(sys.boxDimRef), molRef(statV.mol),
     BETA(statV.forcefield.beta), ewald(statV.forcefield.ewald),
-    cellList(sys.cellList)
+    cellList(sys.cellList), velocity(sys.vel)
   {
     atomForceNew.Init(sys.atomForceRef.Count());
     molForceNew.Init(sys.molForceRef.Count());
@@ -87,6 +88,7 @@ protected:
   XYZArray molForceNew;
   XYZArray& atomForceRecRef;
   XYZArray& molForceRecRef;
+  Velocity& velocity;
 
   PRNG & prng;
   BoxDimensions & boxDimRef;

--- a/src/moves/MultiParticle.h
+++ b/src/moves/MultiParticle.h
@@ -430,6 +430,8 @@ inline void MultiParticle::Accept(const uint rejectState, const uint step)
     swap(molTorqueRef, molTorqueNew);
     //update reciprocal value
     calcEwald->UpdateRecip(bPick);
+    // Update the velocity in box
+    velocity.UpdateBoxVelocity(bPick);
   } else {
     cellList.GridAll(boxDimRef, coordCurrRef, molLookup);
     calcEwald->exgMolCache();

--- a/src/moves/MultiParticleBrownianMotion.h
+++ b/src/moves/MultiParticleBrownianMotion.h
@@ -421,6 +421,8 @@ inline void MultiParticleBrownian::Accept(const uint rejectState, const uint ste
     swap(molTorqueRef, molTorqueNew);
     //update reciprocate value
     calcEwald->UpdateRecip(bPick);
+    // Update the velocity in box
+    velocity.UpdateBoxVelocity(bPick);
   } else {
     cellList.GridAll(boxDimRef, coordCurrRef, molLookup);
     calcEwald->exgMolCache();

--- a/src/moves/Regrowth.h
+++ b/src/moves/Regrowth.h
@@ -166,6 +166,8 @@ inline void Regrowth::Accept(const uint rejectState, const uint step)
 
       //Retotal
       sysPotRef.Total();
+      // Update the velocity
+      velocity.UpdateMolVelocity(molIndex, sourceBox);
     } else {
       cellList.AddMol(molIndex, sourceBox, coordCurrRef);
 

--- a/src/moves/Rotation.h
+++ b/src/moves/Rotation.h
@@ -100,6 +100,8 @@ inline void Rotate::Accept(const uint rejectState, const uint step)
     calcEwald->UpdateRecip(b);
 
     sysPotRef.Total();
+    // Update the velocity
+    velocity.UpdateMolVelocity(m, b);
   }
 
   if(molRemoved) {

--- a/src/moves/TargetedSwap.h
+++ b/src/moves/TargetedSwap.h
@@ -694,6 +694,8 @@ inline void TargetedSwap::Accept(const uint rejectState, const uint step)
 
       //Retotal
       sysPotRef.Total();
+      // Update the velocity
+      velocity.UpdateMolVelocity(molIndex, destBox);
     } else {
       cellList.AddMol(molIndex, sourceBox, coordCurrRef);
       //when weight is 0, MolDestSwap() will not be executed, thus cos/sin

--- a/src/moves/Translate.h
+++ b/src/moves/Translate.h
@@ -109,6 +109,8 @@ inline void Translate::Accept(const uint rejectState, const uint step)
     calcEwald->UpdateRecip(b);
 
     sysPotRef.Total();
+    // Update the velocity
+    velocity.UpdateMolVelocity(m, b);
   }
 
   if(molRemoved) {

--- a/src/moves/VolumeTransfer.h
+++ b/src/moves/VolumeTransfer.h
@@ -261,6 +261,7 @@ inline void VolumeTransfer::Accept(const uint rejectState, const uint step)
       calcEwald->UpdateRecip(box);
       calcEwald->UpdateRecipVec(box);
     }
+    // No need to update the velocity
 
   } else if (rejectState == mv::fail_state::NO_FAIL && regrewGrid) {
     if (GEMC_KIND == mv::GEMC_NVT) {


### PR DESCRIPTION
## GOMC  is now capable of reading the binary velocity data from MD simulation, storing it, updating it, and outputting it at `RestartFreq` steps. 

#### Note: GOMC will output the binary velocity file, **only if initially reads it**. 

During the MC simulation, for any accepted MC move (except volume move), the velocity of the atoms in the molecule that is affected by the move will be reinitialized using Maxwell-Boltzmann distribution. In accepted Multiparticle and MultiParticleBrownian move, which affect all molecules in the box, the velocity of all atoms in the box will be reinitialized using Maxwell-Boltzmann distribution. 

To read the binary velocity, similar to binary coordinates (*.coor), use the following keyword:
```
// example of  NVT or NPT ensemble
binVelocities  0   filename.vel

// example of  GEMC
binVelocities  0   filename_box_0.vel
binVelocities  1   filename_box_1.vel
```

The random velocity implementation is based on [NAMD implementation](https://www.ks.uiuc.edu/Research/namd/mailing_list/namd-l.2011-2012/4124.html). 