### PR TITLE
quick fix to use right index for kinds in InitPartVec

### DIFF
--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -123,16 +123,16 @@ void PDBOutput::InitPartVec()
       for (uint p = placementStart, d = dataStart; p < placementEnd; ++p, ++d) {
         // If you don't want to preserve resID's comment this out -> mol = mI
         molecule = mI;
-        if (molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(*m)].isMultiResidue){
-          FormatAtom(pStr[p], p, molecule + molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(*m)].intraMoleculeResIDs[p - placementStart], 
+        if (molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(mI)].isMultiResidue){
+          FormatAtom(pStr[p], p, molecule + molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(mI)].intraMoleculeResIDs[p - placementStart], 
                     molRef.chain[d],
-                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(*m)].atomNames[p - placementStart], 
-                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(*m)].resNames[p - placementStart]);
+                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(mI)].atomNames[p - placementStart], 
+                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(mI)].resNames[p - placementStart]);
         } else {
           FormatAtom(pStr[p], p, molecule, 
                     molRef.chain[d],
-                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(*m)].atomNames[p - placementStart], 
-                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(*m)].resNames[p - placementStart]);
+                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(mI)].atomNames[p - placementStart], 
+                    molRef.kinds[molRef.GetOriginalKindIndexInCurrentKindArray(mI)].resNames[p - placementStart]);
         }
         ++atomIndex;
       }


### PR DESCRIPTION
Fix for corner case where the original kind index (Ar - 0; Kr - 1) changes due to no Ar being present in Box 0, thus the kind indices would be different from the original kind index (Ar - 1; Kr - 0).  The code already had this feature just had to change the indexing to use the placement index in a trajectory, not the data index in the molecule data. 