### PR TITLE
Added Config parameter "ExpertMode bool" (default false)

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -18,6 +18,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 ConfigSetup::ConfigSetup(void)
 {
   int i;
+  chkErr = true;
   in.restart.enable = false;
   in.restart.step = ULONG_MAX;
   in.restart.recalcTrajectory = false;
@@ -1249,6 +1250,9 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
         printf("%-40s %-s \n", "Info: Constant Parallel Tempering seed", "Active");
       else
         printf("Warning: Constant Parallel Tempering seed set, but will be ignored.\n");
+    } else if(CheckString(line[0], "CheckError")) {
+        chkErr = checkBool(line[1]);
+        printf("%-40s %-s \n", "Info: Ensemble Move Choice Error Checking", chkErr ? "Active" : "Inactive");
     } else {
       std::cout << "Warning: Unknown input " << line[0] << "!" << std::endl;
     }
@@ -1692,23 +1696,47 @@ void ConfigSetup::verifyInputs(void)
     exit(EXIT_FAILURE);
   }
   if(sys.moves.displace == DBL_MAX) {
-    std::cout << "Error: Displacement move frequency is not specified!\n";
-    exit(EXIT_FAILURE);
+    if(chkErr){
+      std::cout << "Error: Displacement move frequency is not specified!\n";
+      exit(EXIT_FAILURE);
+    } else {
+      sys.moves.displace = 0.0;
+      printf("%-40s %-4.4f \n", "ADV USER: Displacement move frequency",
+          sys.moves.displace);
+    }
   }
 #if ENSEMBLE == NPT
   if(sys.moves.volume == DBL_MAX) {
-    std::cout << "Error: Volume move frequency is not specified!" << std::endl;
-    exit(EXIT_FAILURE);
+    if(chkErr){
+      std::cout << "Error: Volume move frequency is not specified!" << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      sys.moves.volume = 0.0;
+      printf("%-40s %-4.4f \n", "ADV USER: Volume move frequency",
+          sys.moves.volume);
+    }
   }
 #endif
 #if ENSEMBLE == GEMC
   if(sys.moves.volume == DBL_MAX) {
-    std::cout << "Error: Volume move frequency is not specified!" << std::endl;
-    exit(EXIT_FAILURE);
+    if(chkErr){
+      std::cout << "Error: Volume move frequency is not specified!" << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      sys.moves.volume = 0.0;
+      printf("%-40s %-4.4f \n", "ADV USER: Volume move frequency",
+          sys.moves.volume);
+    }
   }
   if(sys.moves.transfer == DBL_MAX) {
-    std::cout << "Error: Molecule swap move frequency is not specified!\n";
-    exit(EXIT_FAILURE);
+    if(chkErr){
+      std::cout << "Error: Molecule swap move frequency is not specified!" << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      sys.moves.transfer = 0.0;
+      printf("%-40s %-4.4f \n", "ADV USER: Molecule swap move frequency",
+          sys.moves.transfer);
+    }
   }
   if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.transfer +
               sys.moves.intraSwap + sys.moves.volume + sys.moves.regrowth +
@@ -1720,8 +1748,14 @@ void ConfigSetup::verifyInputs(void)
   }
 #elif ENSEMBLE == NPT
   if(sys.moves.volume == DBL_MAX) {
-    std::cout << "Error: Volume move frequency is not specified!" << std::endl;
-    exit(EXIT_FAILURE);
+    if(chkErr){
+      std::cout << "Error: Volume move frequency is not specified!" << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      sys.moves.volume = 0.0;
+      printf("%-40s %-4.4f \n", "ADV USER: Volume move frequency",
+          sys.moves.volume);
+    }
   }
 
   if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
@@ -1734,8 +1768,14 @@ void ConfigSetup::verifyInputs(void)
 
 #elif ENSEMBLE == GCMC
   if(sys.moves.transfer == DBL_MAX) {
-    std::cout << "Error: Molecule swap move frequency is not specified!\n";
-    exit(EXIT_FAILURE);
+    if(chkErr){
+      std::cout << "Error: Molecule swap move frequency is not specified!" << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      sys.moves.transfer = 0.0;
+      printf("%-40s %-4.4f \n", "ADV USER: Molecule swap move frequency",
+          sys.moves.transfer);
+    }
   }
   if(std::abs(sys.moves.displace + sys.moves.rotate + sys.moves.intraSwap +
               sys.moves.transfer + sys.moves.regrowth + sys.moves.memc +

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -18,7 +18,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 ConfigSetup::ConfigSetup(void)
 {
   int i;
-  chkErr = true;
+  exptMode = true;
   in.restart.enable = false;
   in.restart.step = ULONG_MAX;
   in.restart.recalcTrajectory = false;
@@ -1250,9 +1250,9 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
         printf("%-40s %-s \n", "Info: Constant Parallel Tempering seed", "Active");
       else
         printf("Warning: Constant Parallel Tempering seed set, but will be ignored.\n");
-    } else if(CheckString(line[0], "CheckError")) {
-        chkErr = checkBool(line[1]);
-        printf("%-40s %-s \n", "Info: Ensemble Move Choice Error Checking", chkErr ? "Active" : "Inactive");
+    } else if(CheckString(line[0], "ExpertMode")) {
+        exptMode = checkBool(line[1]);
+        printf("%-40s %-s \n", "Info: Expert Mode", exptMode ? "Active" : "Inactive");
     } else {
       std::cout << "Warning: Unknown input " << line[0] << "!" << std::endl;
     }
@@ -1696,7 +1696,7 @@ void ConfigSetup::verifyInputs(void)
     exit(EXIT_FAILURE);
   }
   if(sys.moves.displace == DBL_MAX) {
-    if(chkErr){
+    if(exptMode){
       std::cout << "Error: Displacement move frequency is not specified!\n";
       exit(EXIT_FAILURE);
     } else {
@@ -1707,7 +1707,7 @@ void ConfigSetup::verifyInputs(void)
   }
 #if ENSEMBLE == NPT
   if(sys.moves.volume == DBL_MAX) {
-    if(chkErr){
+    if(exptMode){
       std::cout << "Error: Volume move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1719,7 +1719,7 @@ void ConfigSetup::verifyInputs(void)
 #endif
 #if ENSEMBLE == GEMC
   if(sys.moves.volume == DBL_MAX) {
-    if(chkErr){
+    if(exptMode){
       std::cout << "Error: Volume move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1729,7 +1729,7 @@ void ConfigSetup::verifyInputs(void)
     }
   }
   if(sys.moves.transfer == DBL_MAX) {
-    if(chkErr){
+    if(exptMode){
       std::cout << "Error: Molecule swap move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1748,7 +1748,7 @@ void ConfigSetup::verifyInputs(void)
   }
 #elif ENSEMBLE == NPT
   if(sys.moves.volume == DBL_MAX) {
-    if(chkErr){
+    if(exptMode){
       std::cout << "Error: Volume move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1768,7 +1768,7 @@ void ConfigSetup::verifyInputs(void)
 
 #elif ENSEMBLE == GCMC
   if(sys.moves.transfer == DBL_MAX) {
-    if(chkErr){
+    if(exptMode){
       std::cout << "Error: Molecule swap move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -18,7 +18,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 ConfigSetup::ConfigSetup(void)
 {
   int i;
-  exptMode = true;
+  exptMode = false;
   in.restart.enable = false;
   in.restart.step = ULONG_MAX;
   in.restart.recalcTrajectory = false;
@@ -1696,7 +1696,7 @@ void ConfigSetup::verifyInputs(void)
     exit(EXIT_FAILURE);
   }
   if(sys.moves.displace == DBL_MAX) {
-    if(exptMode){
+    if(!exptMode){
       std::cout << "Error: Displacement move frequency is not specified!\n";
       exit(EXIT_FAILURE);
     } else {
@@ -1707,7 +1707,7 @@ void ConfigSetup::verifyInputs(void)
   }
 #if ENSEMBLE == NPT
   if(sys.moves.volume == DBL_MAX) {
-    if(exptMode){
+    if(!exptMode){
       std::cout << "Error: Volume move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1719,7 +1719,7 @@ void ConfigSetup::verifyInputs(void)
 #endif
 #if ENSEMBLE == GEMC
   if(sys.moves.volume == DBL_MAX) {
-    if(exptMode){
+    if(!exptMode){
       std::cout << "Error: Volume move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1729,7 +1729,7 @@ void ConfigSetup::verifyInputs(void)
     }
   }
   if(sys.moves.transfer == DBL_MAX) {
-    if(exptMode){
+    if(!exptMode){
       std::cout << "Error: Molecule swap move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1748,7 +1748,7 @@ void ConfigSetup::verifyInputs(void)
   }
 #elif ENSEMBLE == NPT
   if(sys.moves.volume == DBL_MAX) {
-    if(exptMode){
+    if(!exptMode){
       std::cout << "Error: Volume move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {
@@ -1768,7 +1768,7 @@ void ConfigSetup::verifyInputs(void)
 
 #elif ENSEMBLE == GCMC
   if(sys.moves.transfer == DBL_MAX) {
-    if(exptMode){
+    if(!exptMode){
       std::cout << "Error: Molecule swap move frequency is not specified!" << std::endl;
       exit(EXIT_FAILURE);
     } else {

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -890,7 +890,7 @@ public:
   config_setup::Input in;
   config_setup::Output out;
   config_setup::SystemVals sys;
-  bool chkErr;
+  bool exptMode;
   ConfigSetup(void);
   void Init(const char *fileName, MultiSim const*const& multisim);
 private:

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -890,6 +890,7 @@ public:
   config_setup::Input in;
   config_setup::Output out;
   config_setup::SystemVals sys;
+  bool chkErr;
   ConfigSetup(void);
   void Init(const char *fileName, MultiSim const*const& multisim);
 private:


### PR DESCRIPTION
If the user provides "ExpertMode true" in the config file, then Volume, Transfer, and Displacement moves no longer need to exist in the Config file at all, no matter what ensemble.  These values will be set to zero.