### PR TITLE
Implemented box specific enthalpy and compressibility calculations and printing to block averages, as well as compressibility to log files.

### DIFF
--- a/src/BlockOutput.cpp
+++ b/src/BlockOutput.cpp
@@ -169,6 +169,8 @@ void BlockAverages::InitWatchSingle(config_setup::TrackedVars const& tracked)
   blocks[out::PRESSURE_IDX].Init(&outBlock0, &outBlock1, tracked.pressure.block, invSteps, out::PRESSURE, BOXES_WITH_U_NB);
   blocks[out::MOL_NUM_IDX].Init(&outBlock0, &outBlock1, tracked.molNum.block, invSteps, out::MOL_NUM, BOXES_WITH_U_NB);
   blocks[out::DENSITY_IDX].Init(&outBlock0, &outBlock1, tracked.density.block, invSteps, out::DENSITY, BOXES_WITH_U_NB);
+  blocks[out::COMPRESSIBILITY_IDX].Init(&outBlock0, &outBlock1, tracked.pressure.block, invSteps, out::COMPRESSIBILITY, BOXES_WITH_U_NB);
+  blocks[out::ENTHALPY_IDX].Init(&outBlock0, &outBlock1, tracked.pressure.block, invSteps, out::ENTHALPY, BOXES_WITH_U_NB);
   blocks[out::SURF_TENSION_IDX].Init(&outBlock0, &outBlock1, tracked.surfaceTension.block, invSteps, out::SURF_TENSION, BOXES_WITH_U_NB);
 #if ENSEMBLE == GEMC
   blocks[out::VOLUME_IDX].Init(&outBlock0, &outBlock1, tracked.volume.block, invSteps, out::VOLUME, BOXES_WITH_U_NB);
@@ -192,6 +194,8 @@ void BlockAverages::InitWatchSingle(config_setup::TrackedVars const& tracked)
     blocks[out::PRESSURE_IDX].SetRef(&var->pressure[b], b);
     blocks[out::MOL_NUM_IDX].SetRef(&var->numByBox[b], b);
     blocks[out::DENSITY_IDX].SetRef(&var->densityTot[b], b);
+    blocks[out::COMPRESSIBILITY_IDX].SetRef(&var->compressability[b], b);
+    blocks[out::ENTHALPY_IDX].SetRef(&var->enthalpy[b], b);
     blocks[out::SURF_TENSION_IDX].SetRef(&var->surfaceTens[b], b);
 #if ENSEMBLE == GEMC
     blocks[out::VOLUME_IDX].SetRef(&var->volumeRef[b], b);

--- a/src/ConsoleOutput.cpp
+++ b/src/ConsoleOutput.cpp
@@ -82,6 +82,10 @@ void ConsoleOutput::DoOutput(const ulong step)
         std::cout << std::endl;
       }
 
+      if (enableCompressibility) {
+        PrintCompressibility(b, step);
+        std::cout << std::endl;
+      }
     }
 
   }
@@ -267,6 +271,19 @@ void ConsoleOutput::PrintPressureTensor(const uint box, const ulong step) const
     // Else, just print the diameter of the pressure Tensor, W11, W22, W33
     printElement(var->pressureTens[box][i][i], elementWidth);
   }
+  std::cout << std::endl;
+}
+
+void ConsoleOutput::PrintCompressibility(const uint box, const ulong step) const
+{
+  std::string title = "COMPRESS_";
+  sstrm::Converter toStr;
+  std::string numStr = "";
+  toStr << box;
+  toStr >> numStr;
+  title += numStr + ":";
+  printElementStep(title, step + 1, elementWidth);
+  printElement((var->pressure[box]) * (var->volumeRef[box]) / (var->numByBox[box]) / (var->T_in_K) / (UNIT_CONST_H::unit::K_MOLECULE_PER_A3_TO_BAR), elementWidth);
   std::cout << std::endl;
 }
 

--- a/src/ConsoleOutput.h
+++ b/src/ConsoleOutput.h
@@ -44,7 +44,9 @@ public:
     stepsPerOut = output.console.frequency;
     enableEnergy = output.statistics.vars.energy.fluct;
     enablePressure = output.statistics.vars.pressure.fluct;
+    enableCompressibility = output.statistics.vars.pressure.fluct;
     enableSurfTension = output.statistics.vars.surfaceTension.fluct;
+
 #ifdef VARIABLE_VOLUME
     enableVolume = output.statistics.vars.volume.fluct;
 #else
@@ -67,12 +69,13 @@ public:
   virtual void DoOutputRestart(const ulong step);
 private:
   const static int elementWidth = 16;
-  bool enableEnergy, enablePressure, enableDens, enableVolume, enableMol;
+  bool enableEnergy, enablePressure, enableDens, enableVolume, enableMol, enableCompressibility;
   bool enableSurfTension, enableStat;
   void PrintMove(const uint box, const ulong step) const;
   void PrintMoveStat(const uint box, const ulong step) const;
   void PrintStatistic(const uint box, const ulong step) const;
   void PrintPressureTensor(const uint box, const ulong step) const;
+  void PrintCompressibility(const uint box, const ulong step) const;
   void PrintEnergy(const uint box, Energy const& en, const ulong step) const;
   void PrintEnergyTitle();
   void PrintStatisticTitle();

--- a/src/OutConst.cpp
+++ b/src/OutConst.cpp
@@ -18,6 +18,8 @@ const std::string ENERGY_REAL = "EN_REAL";
 const std::string ENERGY_RECIP = "EN_RECIP";
 const std::string VIRIAL_TOTAL = "TOTAL_VIR";
 const std::string PRESSURE = "PRESSURE";
+const std::string COMPRESSIBILITY = "COMPRESSIBILITY";
+const std::string ENTHALPY = "ENTHALPY";
 #if ENSEMBLE == GEMC
 const std::string HEAT_OF_VAP = "HEAT_VAP";
 const std::string VOLUME = "VOLUME";

--- a/src/OutConst.h
+++ b/src/OutConst.h
@@ -38,20 +38,24 @@ extern const std::string MOL_NUM;
 static const uint MOL_NUM_IDX = 10;
 extern const std::string DENSITY;
 static const uint DENSITY_IDX = 11;
+extern const std::string COMPRESSIBILITY;
+static const uint COMPRESSIBILITY_IDX = 12;
 extern const std::string SURF_TENSION;
-static const uint SURF_TENSION_IDX = 12;
+static const uint SURF_TENSION_IDX = 13;
+static const uint ENTHALPY_IDX = 14;
+extern const std::string ENTHALPY;
 #if ENSEMBLE == NVT || ENSEMBLE == GCMC
-static const uint TOTAL_SINGLE = 13;
+static const uint TOTAL_SINGLE = 18;
 #elif ENSEMBLE == NPT
 extern const std::string VOLUME;
-static const uint VOLUME_IDX = 13;
-static const uint TOTAL_SINGLE = 14;
+static const uint VOLUME_IDX = 15;
+static const uint TOTAL_SINGLE = 16;
 #else
 extern const std::string VOLUME;
 extern const std::string HEAT_OF_VAP;
-static const uint VOLUME_IDX = 13;
-static const uint HEAT_OF_VAP_IDX = 14;
-static const uint TOTAL_SINGLE = 15;
+static const uint VOLUME_IDX = 15;
+static const uint HEAT_OF_VAP_IDX = 16;
+static const uint TOTAL_SINGLE = 17;
 #endif
 
 //MULTI

--- a/src/OutputVars.cpp
+++ b/src/OutputVars.cpp
@@ -165,6 +165,8 @@ void OutputVars::CalcAndConvert(ulong step)
         pressure[b] = rawPressure[b];
         pressure[b] *= unit::K_MOLECULE_PER_A3_TO_BAR;
 
+        compressability[b] = (pressure[b]) * (volumeRef[b]) / numByBox[b] / (T_in_K) / (UNIT_CONST_H::unit::K_MOLECULE_PER_A3_TO_BAR);
+        enthalpy[b] = (energyRef[b].total / numByBox[b] + rawPressure[b] * volumeRef[b] / numByBox[b]) * UNIT_CONST_H::unit::K_TO_KJ_PER_MOL;
 
 #if ENSEMBLE == GEMC
         // delta Hv = (Uv-Ul) + P(Vv-Vl)

--- a/src/OutputVars.h
+++ b/src/OutputVars.h
@@ -39,8 +39,8 @@ public:
 //private:
   //Intermediate vars.
   uint * numByBox, * numByKindBox;
-  double * molFractionByKindBox, * densityByKindBox,
-         pressure[BOXES_WITH_U_NB], densityTot[BOX_TOTAL];
+  double *molFractionByKindBox, *densityByKindBox,
+      pressure[BOXES_WITH_U_NB], densityTot[BOX_TOTAL], compressability[BOXES_WITH_U_NB], enthalpy[BOXES_WITH_U_NB];
   double pressureTens[BOXES_WITH_U_NB][3][3];
   double surfaceTens[BOXES_WITH_U_NB];
   ulong pCalcFreq;


### PR DESCRIPTION
Currently Enthalpy needs to be hand calculated from TOT_EN, pressure and volume of the system. This small cosmetic change prints enthalpy as calculated by formula H = U + PV (in units of kJ/mol), and compressibility as calculated by formula Z = PV/nRT. 