### PR TITLE
Improve CUDA Memory Manager behavior for some edge cases -- Fixes issue #401

### DIFF
--- a/src/GPU/CUDAMemoryManager.cu
+++ b/src/GPU/CUDAMemoryManager.cu
@@ -28,7 +28,7 @@ cudaError_t CUDAMemoryManager::freeMemory(void *address, std::string var_name)
   if(allocatedPointers.find(address) != allocatedPointers.end()) {
     totalAllocatedBytes -= allocatedPointers[address].first;
     allocatedPointers.erase(address);
-  } else if (address != NULL) {
+  } else if (address != nullptr) {
     std::cout << "Warning! You are trying to free " << var_name << " but it has already been freed\n"
               << "\tor was never allocated!\n";
   }

--- a/src/GPU/CUDAMemoryManager.cu
+++ b/src/GPU/CUDAMemoryManager.cu
@@ -42,7 +42,7 @@ bool CUDAMemoryManager::isFreed()
   while(allocatedPointers.size() != 0) {
     auto it = allocatedPointers.begin();
     std::cout << "You forgot to free memory " << it->second.second
-              << " with " << it->second.first << " bytes allocated to it!\n";
+              << " with " << it->second.first << " bytes allocated!\n";
     std::cout << "I am going to free it for you!\n";
     freeMemory(it->first, it->second.second);
   }

--- a/src/GPU/CUDAMemoryManager.cu
+++ b/src/GPU/CUDAMemoryManager.cu
@@ -28,7 +28,7 @@ cudaError_t CUDAMemoryManager::freeMemory(void *address, std::string var_name)
   if(allocatedPointers.find(address) != allocatedPointers.end()) {
     totalAllocatedBytes -= allocatedPointers[address].first;
     allocatedPointers.erase(address);
-  } else {
+  } else if (address != NULL) {
     std::cout << "Warning! You are trying to free " << var_name << " but it has already been freed\n"
               << "\tor was never allocated!\n";
   }

--- a/src/GPU/CUDAMemoryManager.cu
+++ b/src/GPU/CUDAMemoryManager.cu
@@ -16,8 +16,12 @@ cudaError_t CUDAMemoryManager::mallocMemory(void **address, unsigned int size, s
   cudaError_t ret = cudaMalloc(address, size);
   allocatedPointers[*address] = make_pair(size, var_name);
   totalAllocatedBytes += size;
+  if (size == 0) {
+    std::cout << "Warning! You are trying to allocate " << var_name << " with a size of zero bytes!\n";
+  }
   return ret;
 }
+
 
 cudaError_t CUDAMemoryManager::freeMemory(void *address, std::string var_name)
 {
@@ -25,11 +29,12 @@ cudaError_t CUDAMemoryManager::freeMemory(void *address, std::string var_name)
     totalAllocatedBytes -= allocatedPointers[address].first;
     allocatedPointers.erase(address);
   } else {
-    std::cout << "Warning! You are trying to free " << var_name << " where it was freed\n" <<
-              "\tor never been allocated before!\n";
+    std::cout << "Warning! You are trying to free " << var_name << " but it has already been freed\n"
+              << "\tor was never allocated!\n";
   }
   return cudaFree(address);
 }
+
 
 bool CUDAMemoryManager::isFreed()
 {


### PR DESCRIPTION
The CUDA Memory Manager, which tracks allocations and deallocations of CUDA memory, doesn't work properly for the edge  case of allocating zero bytes of memory. First, it should generate a warning, as there isn't a good reason to allocate zero bytes.

And, if done multiple times, generates a spurious warning message when freeing the variables, as CudaMalloc maps all allocations of zero bytes map to nullptr, so the multiple allocations of zero bytes end up stepping on each other in the lookup table, as they don't have unique addresses.

The patch changes the code so that it (a) generates a warning when allocating zero bytes and (b) doesn't generate a warning when freeing an allocation with an address of nullptr. Note that the code does check at some point to make sure that all allocations have been freed, so reassigning a pointer to nullptr to get around this warning won't solve any problems.

The only potential problem I see with the patch is that it doesn't handle the case where someone to initializes a pointer to nullptr, never allocates memory, and then frees it. I would expect that to cause other problems, but something to think about when considering whether the patch should be merged.