### PR TITLE
Fix #407 Mie potential with non-integer repulsion exponents

### DIFF
--- a/lib/NumLib.h
+++ b/lib/NumLib.h
@@ -83,11 +83,7 @@ inline double MeanA(std::vector<uint> const& v1,
                     std::vector<uint> const& v2,
                     const uint ix1, const uint ix2)
 {
-#ifdef MIE_INT_ONLY
-  return (v1[ix1] + v2[ix2]) / 2;
-#else
-  return ((double)(v1[ix1] + v2[ix2])) / 2.0;
-#endif
+  return ((double)(v1[ix1] + v2[ix2])) * 0.5;
 }
 //Geometric mean.
 inline double MeanG(std::vector<double> const& v1,

--- a/src/FFExp6.h
+++ b/src/FFExp6.h
@@ -7,7 +7,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #ifndef FF_EXP6_H
 #define FF_EXP6_H
 
-#include "EnsemblePreprocessor.h" //For "MIE_INT_ONLY" preprocessor.
 #include "FFConst.h" //constants related to particles.
 #include "BasicTypes.h" //for uint
 #include "NumLib.h" //For Cb, Sq

--- a/src/FFParticle.cpp
+++ b/src/FFParticle.cpp
@@ -63,13 +63,8 @@ void FFParticle::Init(ff_setup::Particle const& mie,
   nameFirst = new std::string [size];
   nameSec = new std::string [size];
 
-#ifdef MIE_INT_ONLY
-  n = new uint [size];
-  n_1_4 = new uint [size];
-#else
   n = new double [size];
   n_1_4 = new double [size];
-#endif
   epsilon = new double [size];
   epsilon_cn = new double [size];
   epsilon_cn_6 = new double [size];
@@ -270,15 +265,8 @@ inline void FFParticle::CalcAdd_1_4(double& en, const double distSq,
 
   uint index = FlatIndex(kind1, kind2);
   double rRat2 = sigmaSq_1_4[index] / distSq;
-  double rRat4 = rRat2 * rRat2;
-  double attract = rRat4 * rRat2;
-#ifdef MIE_INT_ONLY
-  uint n_ij = n_1_4[index];
-  double repulse = num::POW(rRat2, rRat4, attract, n_ij);
-#else
-  double n_ij = n_1_4[index];
-  double repulse = pow(sqrt(rRat2), n_ij);
-#endif
+  double attract = rRat2 * rRat2 * rRat2;
+  double repulse = pow(sqrt(rRat2), n_1_4[index]);
 
   en += epsilon_cn_1_4[index] * (repulse - attract);
 }

--- a/src/FFParticle.h
+++ b/src/FFParticle.h
@@ -7,7 +7,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #ifndef FF_PARTICLE_H
 #define FF_PARTICLE_H
 
-#include "EnsemblePreprocessor.h" //For "MIE_INT_ONLY" preprocessor.
 #include "FFConst.h" //constants related to particles.
 #include "Forcefield.h"
 #include "BasicTypes.h" //for uint
@@ -135,11 +134,7 @@ protected:
   std::string *nameSec;
 
   //vars for LJ-LJ pairs
-#ifdef MIE_INT_ONLY
-  uint *n, *n_1_4;
-#else
   double *n, *n_1_4;
-#endif
   //For LJ eps_cn(en) --> 4eps, eps_cn_6 --> 24eps, eps_cn_n --> 48eps
   double *sigmaSq, *sigmaSq_1_4, *epsilon, *epsilon_1_4, *epsilon_cn,
          *epsilon_cn_1_4, *epsilon_cn_6, *epsilon_cn_6_1_4, *nOver6,

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -183,7 +183,12 @@ std::string FFBase::LoadLine(Reader & param, std::string const& firstVar)
 void Particle::Read(Reader & param, std::string const& firstVar)
 {
   double e, s, e_1_4, s_1_4, dummy1, dummy2;
+#ifdef MIE_INT_ONLY
   uint expN, expN_1_4;
+#else
+  double expN, expN_1_4;
+#endif
+  // uint expN, expN_1_4;
   std::stringstream values(LoadLine(param, firstVar));
   if (isCHARMM()) { //if lj
     values >> dummy1;
@@ -216,8 +221,13 @@ void Particle::Read(Reader & param, std::string const& firstVar)
   Add(e, s, expN, e_1_4, s_1_4, expN_1_4);
 }
 
+#ifdef MIE_INT_ONLY
 void Particle::Add(double e, double s, const uint expN,
                    double e_1_4, double s_1_4, const uint expN_1_4)
+#else
+void Particle::Add(double e, double s, const double expN,
+                   double e_1_4, double s_1_4, const double expN_1_4)
+#endif
 {
   if (isCHARMM()) {
     e *= -1.0;

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -188,7 +188,6 @@ void Particle::Read(Reader & param, std::string const& firstVar)
 #else
   double expN, expN_1_4;
 #endif
-  // uint expN, expN_1_4;
   std::stringstream values(LoadLine(param, firstVar));
   if (isCHARMM()) { //if lj
     values >> dummy1;

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -183,11 +183,7 @@ std::string FFBase::LoadLine(Reader & param, std::string const& firstVar)
 void Particle::Read(Reader & param, std::string const& firstVar)
 {
   double e, s, e_1_4, s_1_4, dummy1, dummy2;
-#ifdef MIE_INT_ONLY
-  uint expN, expN_1_4;
-#else
   double expN, expN_1_4;
-#endif
   std::stringstream values(LoadLine(param, firstVar));
   if (isCHARMM()) { //if lj
     values >> dummy1;
@@ -220,13 +216,8 @@ void Particle::Read(Reader & param, std::string const& firstVar)
   Add(e, s, expN, e_1_4, s_1_4, expN_1_4);
 }
 
-#ifdef MIE_INT_ONLY
-void Particle::Add(double e, double s, const uint expN,
-                   double e_1_4, double s_1_4, const uint expN_1_4)
-#else
 void Particle::Add(double e, double s, const double expN,
                    double e_1_4, double s_1_4, const double expN_1_4)
-#endif
 {
   if (isCHARMM()) {
     e *= -1.0;
@@ -245,11 +236,7 @@ void Particle::Add(double e, double s, const double expN,
 void NBfix::Read(Reader & param, std::string const& firstVar)
 {
   double e, s, e_1_4, s_1_4;
-#ifdef MIE_INT_ONLY
-  uint expN, expN_1_4;
-#else
   double expN, expN_1_4;
-#endif
 
   std::stringstream values(LoadLine(param, firstVar));
   values >> e >> s;
@@ -276,19 +263,8 @@ void NBfix::Read(Reader & param, std::string const& firstVar)
   Add(e, s, expN, e_1_4, s_1_4, expN_1_4);
 }
 
-void NBfix::Add(double e, double s,
-#ifdef MIE_INT_ONLY
-                const uint expN,
-#else
-                const double expN,
-#endif
-                double e_1_4, double s_1_4,
-#ifdef MIE_INT_ONLY
-                const uint expN_1_4
-#else
-                const double expN_1_4
-#endif
-               )
+void NBfix::Add(double e, double s, const double expN, double e_1_4, double s_1_4,
+                const double expN_1_4)
 {
   if (isCHARMM()) {
     e *= -1.0;

--- a/src/FFSetup.h
+++ b/src/FFSetup.h
@@ -94,24 +94,14 @@ public:
   Particle(void) : FFBase(1) {}
 
   virtual void Read(Reader & param, std::string const& firstVar);
-#ifdef MIE_INT_ONLY
-  void Add(double e, double s, const uint expN,
-           double e_1_4, double s_1_4, const uint expN_1_4);
-#else
   void Add(double e, double s, const double expN,
            double e_1_4, double s_1_4, const double expN_1_4);
-#endif
 #ifndef NDEBUG
   void PrintBrief();
 #endif
 //    private:
   std::vector<double> sigma, epsilon, sigma_1_4, epsilon_1_4;
-#ifdef MIE_INT_ONLY
-  std::vector<uint> n, n_1_4;
-#else
   std::vector<double> n, n_1_4;
-#endif
-
 };
 
 class NBfix : public ReadableBaseWithFirst, public FFBase
@@ -120,26 +110,11 @@ public:
   NBfix() : FFBase(2) {}
 
   virtual void Read(Reader & param, std::string const& firstVar);
-  void Add(double e, double s,
-#ifdef MIE_INT_ONLY
-           const uint expN,
-#else
-           const double expN,
-#endif
-           double e_1_4, double s_1_4,
-#ifdef MIE_INT_ONLY
-           const uint expN_1_4
-#else
-           const double expN_1_4
-#endif
-          );
+  void Add(double e, double s, const double expN, double e_1_4, double s_1_4,
+           const double expN_1_4);
 //    private:
   std::vector<double> sigma, epsilon, sigma_1_4, epsilon_1_4;
-#ifdef MIE_INT_ONLY
-  std::vector<uint> n, n_1_4;
-#else
   std::vector<double> n, n_1_4;
-#endif
 };
 
 

--- a/src/FFSetup.h
+++ b/src/FFSetup.h
@@ -94,14 +94,23 @@ public:
   Particle(void) : FFBase(1) {}
 
   virtual void Read(Reader & param, std::string const& firstVar);
+#ifdef MIE_INT_ONLY
   void Add(double e, double s, const uint expN,
            double e_1_4, double s_1_4, const uint expN_1_4);
+#else
+  void Add(double e, double s, const double expN,
+           double e_1_4, double s_1_4, const double expN_1_4);
+#endif
 #ifndef NDEBUG
   void PrintBrief();
 #endif
 //    private:
   std::vector<double> sigma, epsilon, sigma_1_4, epsilon_1_4;
+#ifdef MIE_INT_ONLY
   std::vector<uint> n, n_1_4;
+#else
+  std::vector<double> n, n_1_4;
+#endif
 
 };
 

--- a/src/FFShift.h
+++ b/src/FFShift.h
@@ -7,7 +7,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #ifndef FF_SHIFT_H
 #define FF_SHIFT_H
 
-#include "EnsemblePreprocessor.h" //For "MIE_INT_ONLY" preprocessor.
 #include "FFConst.h" //constants related to particles.
 #include "BasicTypes.h" //for uint
 #include "NumLib.h" //For Cb, Sq
@@ -132,15 +131,8 @@ inline void FF_SHIFT::CalcAdd_1_4(double& en, const double distSq,
 
   uint index = FlatIndex(kind1, kind2);
   double rRat2 = sigmaSq_1_4[index] / distSq;
-  double rRat4 = rRat2 * rRat2;
-  double attract = rRat4 * rRat2;
-#ifdef MIE_INT_ONLY
-  uint n_ij = n_1_4[index];
-  double repulse = num::POW(rRat2, rRat4, attract, n_ij);
-#else
-  double n_ij = n_1_4[index];
-  double repulse = pow(sqrt(rRat2), n_ij);
-#endif
+  double attract = rRat2 * rRat2 * rRat2;
+  double repulse = pow(sqrt(rRat2), n_1_4[index]);
 
   en += (epsilon_cn_1_4[index] * (repulse - attract) - shiftConst_1_4[index]);
 }

--- a/src/FFSwitch.h
+++ b/src/FFSwitch.h
@@ -7,7 +7,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #ifndef FF_SWITCH_H
 #define FF_SWITCH_H
 
-#include "EnsemblePreprocessor.h" //For "MIE_INT_ONLY" preprocessor.
 #include "FFConst.h" //constants related to particles.
 #include "BasicTypes.h" //for uint
 #include "NumLib.h" //For Cb, Sq
@@ -126,17 +125,10 @@ inline void FF_SWITCH::CalcAdd_1_4(double& en, const double distSq,
   double rCutSq_rijSq_Sq = rCutSq_rijSq * rCutSq_rijSq;
 
   double rRat2 = sigmaSq_1_4[index] / distSq;
-  double rRat4 = rRat2 * rRat2;
-  double attract = rRat4 * rRat2;
-#ifdef MIE_INT_ONLY
-  uint n_ij = n_1_4[index];
-  double repulse = num::POW(rRat2, rRat4, attract, n_ij);
-#else
-  double n_ij = n_1_4[index];
-  double repulse = pow(sqrt(rRat2), n_ij);
-#endif
+  double attract = rRat2 * rRat2 * rRat2;
+  double repulse = pow(sqrt(rRat2), n_1_4[index]);
 
-  double fE = rCutSq_rijSq_Sq * factor2 * (factor1 + 2 * distSq);
+  double fE = rCutSq_rijSq_Sq * factor2 * (factor1 + 2.0 * distSq);
 
   const double factE = ( distSq > rOnSq ? fE : 1.0);
 
@@ -184,12 +176,10 @@ inline double FF_SWITCH::CalcEn(const double distSq, const uint index) const
   double rCutSq_rijSq = forcefield.rCutSq - distSq;
   double rCutSq_rijSq_Sq = rCutSq_rijSq * rCutSq_rijSq;
   double rRat2 = sigmaSq[index] / distSq;
-  double rRat4 = rRat2 * rRat2;
-  double attract = rRat4 * rRat2;
-  double n_ij = n[index];
-  double repulse = pow(rRat2, (n_ij * 0.5));
+  double attract = rRat2 * rRat2 * rRat2;
+  double repulse = pow(rRat2, (n[index] * 0.5));
 
-  double fE = rCutSq_rijSq_Sq * factor2 * (factor1 + 2 * distSq);
+  double fE = rCutSq_rijSq_Sq * factor2 * (factor1 + 2.0 * distSq);
   const double factE = ( distSq > rOnSq ? fE : 1.0);
 
   return (epsilon_cn[index] * (repulse - attract)) * factE;
@@ -225,12 +215,10 @@ inline double FF_SWITCH::CalcVir(const double distSq, const uint index) const
 
   double rNeg2 = 1.0 / distSq;
   double rRat2 = rNeg2 * sigmaSq[index];
-  double rRat4 = rRat2 * rRat2;
-  double attract = rRat4 * rRat2;
-  double n_ij = n[index];
-  double repulse = pow(rRat2, (n_ij * 0.5));
+  double attract = rRat2 * rRat2 * rRat2;
+  double repulse = pow(rRat2, (n[index] * 0.5));
 
-  double fE = rCutSq_rijSq_Sq * factor2 * (factor1 + 2 * distSq);
+  double fE = rCutSq_rijSq_Sq * factor2 * (factor1 + 2.0 * distSq);
   double fW = 12.0 * factor2 * rCutSq_rijSq * (rOnSq - distSq);
 
   const double factE = ( distSq > rOnSq ? fE : 1.0);

--- a/src/FFSwitchMartini.h
+++ b/src/FFSwitchMartini.h
@@ -7,7 +7,6 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 #ifndef FF_SWITCH_MARTINI_H
 #define FF_SWITCH_MARTINI_H
 
-#include "EnsemblePreprocessor.h" //For "MIE_INT_ONLY" preprocessor.
 #include "FFConst.h" //constants related to particles.
 #include "BasicTypes.h" //for uint
 #include "NumLib.h" //For Cb, Sq
@@ -225,15 +224,8 @@ inline void FF_SWITCH_MARTINI::CalcAdd_1_4(double& en, const double distSq,
 
   uint index = FlatIndex(kind1, kind2);
   double r_2 = 1.0 / distSq;
-  double r_4 = r_2 * r_2;
-  double r_6 = r_4 * r_2;
-#ifdef MIE_INT_ONLY
-  uint n_ij = n_1_4[index];
-  double r_n = num::POW(r_2, r_4, attract, n_ij);
-#else
-  double n_ij = n_1_4[index];
-  double r_n = pow(sqrt(r_2), n_ij);
-#endif
+  double r_6 = r_2 * r_2 * r_2;
+  double r_n = pow(sqrt(r_2), n_1_4[index]);
 
   double rij_ron = sqrt(distSq) - rOn;
   double rij_ron_2 = rij_ron * rij_ron;


### PR DESCRIPTION
The patch removes the #define MIE_INT_ONLY and corrects an error in the ffsetup::Particle that always used uint for the exponents.