### PR TITLE
Resevoir cutoff > 1/2 box length shouldn't be enforced in GCMC

### DIFF
--- a/src/BoxDimensions.cpp
+++ b/src/BoxDimensions.cpp
@@ -66,10 +66,11 @@ void BoxDimensions::Init(config_setup::RestartSettings const& restart,
 
     axis.Set(b, cellBasis[b].Length(0), cellBasis[b].Length(1),
              cellBasis[b].Length(2));
-
-    if(axis.Get(b).Min() < 2.0 * rCut[b]) {
-      printf("Error: Cutoff value is larger than half of minimum BOX%d length!\n", b);
-      exit(EXIT_FAILURE);
+    if(b < BOXES_WITH_U_NB) {
+      if(axis.Get(b).Min() < 2.0 * rCut[b]) {
+        printf("Error: Cutoff value is larger than half of minimum BOX%d length!\n", b);
+        exit(EXIT_FAILURE);
+      }
     }
     //Find Cosine Angle of alpha, beta and gamma
     cosAngle[b][0] = Dot(cellBasis[b].Get(1), cellBasis[b].Get(2)) /

--- a/src/BoxDimensionsNonOrth.cpp
+++ b/src/BoxDimensionsNonOrth.cpp
@@ -91,10 +91,11 @@ void BoxDimensionsNonOrth::Init(config_setup::RestartSettings const& restart,
     //XYZ unslant = TransformUnSlant(cellLength.Get(b), b);
     //axis.Set(b, unslant.x, unslant.y, unslant.z);
     axis.Set(b, cellLength[b]);
-
-    if(axis.Get(b).Min() < 2.0 * rCut[b]) {
-      printf("Error: Cutoff value is larger than half of minimum BOX%d length!\n", b);
-      exit(EXIT_FAILURE);
+    if(b < BOXES_WITH_U_NB) {
+      if(axis.Get(b).Min() < 2.0 * rCut[b]) {
+        printf("Error: Cutoff value is larger than half of minimum BOX%d length!\n", b);
+        exit(EXIT_FAILURE);
+      }
     }
   }
   //Set half axis


### PR DESCRIPTION
We don't calculate energy of the reservoir in GCMC by limiting energy calculations to box b < BOXES_WITH_U_NB, so we should use the same upper bound on box for error checking the cutoff.