### PR TITLE
Restart pdb uses the atoms' input occupancy instead of overwriting occ with 0.

### DIFF
--- a/src/Checkpoint.h
+++ b/src/Checkpoint.h
@@ -173,7 +173,7 @@ class Checkpoint
                 // PRNG PT Vars
                 ar & saveArrayPT;
                 ar & seedLocationPT;
-                ar & seedLeftP  T;
+                ar & seedLeftPT;
                 ar & seedValuePT;
             }
             #endif

--- a/src/CheckpointSetup.cpp
+++ b/src/CheckpointSetup.cpp
@@ -169,6 +169,7 @@ void CheckpointSetup::SetPDBSetupAtoms(){
       chkObj.originalAtoms.y[p] = pdbAtomsRef.y[d];
       chkObj.originalAtoms.z[p] = pdbAtomsRef.z[d];
       chkObj.originalAtoms.beta[p] = pdbAtomsRef.beta[d];
+      chkObj.originalAtoms.occ[p] = pdbAtomsRef.occ[d];
       chkObj.originalAtoms.box[p] = pdbAtomsRef.box[d];
     }
   }

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -33,6 +33,7 @@ Molecules::~Molecules(void)
   delete[] countByKind;
   delete[] chain;
   delete[] beta;
+  delete[] occ;
   delete[] kinds;
   delete[] pairEnCorrections;
   delete[] pairVirCorrections;
@@ -68,6 +69,7 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   kIndex = vect::transfer<uint>(setup.mol.molVars.moleculeKinds);
   chain = vect::transfer<char>(atoms.chainLetter);
   beta =  vect::transfer<double>(atoms.beta);
+  occ =  vect::transfer<double>(atoms.occ);
 
   start[count] = atoms.x.size();
   kIndexCount = setup.mol.molVars.moleculeKinds.size();
@@ -186,6 +188,7 @@ bool Molecules::operator==(const Molecules & other){
   for (int a = 0; a < atomCount; ++a){
     result &= (chain[a] == other.chain[a]);
     result &= (beta[a] == other.beta[a]);
+    result &= (occ[a] == other.occ[a]);
   }
   for (int k = 0; k < kindsCount; ++k){
     result &= (countByKind[k] == other.countByKind[k]);

--- a/src/Molecules.h
+++ b/src/Molecules.h
@@ -121,6 +121,7 @@ public:
   uint* countByKind;
   char* chain;
   double* beta;
+  double* occ;
 
 
   MoleculeKind * kinds;

--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -291,7 +291,28 @@ void PDBOutput::PrintCrystRest(const uint b, const ulong step, Writer & out)
   out.file << outStr << std::endl;
 }
 
+// Restart PDB
+void PDBOutput::InsertAtomInLine(std::string & line, XYZ const& coor,
+                                 double const& occ,
+                                 double const& beta)
+{
+  using namespace pdb_entry::atom::field;
+  using namespace pdb_entry;
+  sstrm::Converter toStr;
+  //Fill in particle's stock string with new x, y, z, and occupancy
+  toStr.Fixed().Align(x::ALIGN).Precision(x::PRECISION);
+  toStr.Replace(line, coor.x, x::POS);
+  toStr.Fixed().Align(y::ALIGN).Precision(y::PRECISION);
+  toStr.Replace(line, coor.y, y::POS);
+  toStr.Fixed().Align(z::ALIGN).Precision(z::PRECISION);
+  toStr.Replace(line, coor.z, z::POS);
+  toStr.Align(occupancy::ALIGN);
+  toStr.Replace(line, occ, occupancy::POS);
+  toStr.Align(beta::ALIGN);
+  toStr.Replace(line, beta, beta::POS);
+}
 
+// PDB trajectory
 void PDBOutput::InsertAtomInLine(std::string & line, XYZ const& coor,
                                  std::string const& occ,
                                  double const& beta)
@@ -369,7 +390,7 @@ void PDBOutput::PrintAtomsRebuildRestart(const uint b)
                     molRef.kinds[k].atomNames[d - dataStart], molRef.kinds[k].resNames[d - dataStart]);
         }
         //Fill in particle's stock string with new x, y, z, and occupancy
-        InsertAtomInLine(line, coor, occupancy::BOX[0], molRef.beta[d]);
+        InsertAtomInLine(line, coor, molRef.occ[d], molRef.beta[d]);
         //Write finished string out.
         outRebuildRestart[b].file << line << std::endl;
         ++atom;

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -72,6 +72,9 @@ private:
   void InsertAtomInLine(std::string & line, XYZ const& coor,
                         std::string const& occ, double const& beta);
 
+  void InsertAtomInLine(std::string & line, XYZ const& coor,
+                        double const& occ, double const& beta);
+
   void PrintEnd(Writer & out)
   {
     out.file << "END" << std::endl;

--- a/src/PDBSetup.cpp
+++ b/src/PDBSetup.cpp
@@ -108,10 +108,12 @@ void Atoms::SetRestart(config_setup::RestartSettings const& r )
 void Atoms::Assign(std::string const& resName,
                    const char l_chain, const double l_x,
                    const double l_y, const double l_z,
-                   const double l_beta)
+                   const double l_beta,
+                   const double l_occ)
 {
   //box.push_back((bool)(restart?(uint)(l_occ):currBox));
   beta.push_back(l_beta);
+  occ.push_back(l_occ);
   box.push_back(currBox);
   ++numAtomsInBox[currBox];
   resNames.push_back(resName);
@@ -142,7 +144,7 @@ void Atoms::Read(FixedWidthReader & file)
   if(recalcTrajectory && (uint)l_occ != currBox) {
     return;
   }
-  Assign(resName, l_chain, l_x, l_y, l_z, l_beta);
+  Assign(resName, l_chain, l_x, l_y, l_z, l_beta, l_occ);
 }
 
 void Atoms::Clear()
@@ -152,6 +154,7 @@ void Atoms::Clear()
   y.clear();
   z.clear();
   beta.clear();
+  occ.clear();
   box.clear();
   resNames.clear();
   count = 0;

--- a/src/PDBSetup.h
+++ b/src/PDBSetup.h
@@ -107,7 +107,8 @@ public:
               const double l_x,
               const double l_y,
               const double l_z,
-              const double l_beta);
+              const double l_beta,
+              const double l_occ);
 
   void Read(FixedWidthReader & file);
   void Clear();
@@ -117,7 +118,8 @@ public:
   //member data
   std::vector<char> chainLetter; //chain ids of each atom respectively
   std::vector<double> x, y, z; //coordinates of each particle
-  std::vector<double> beta;  //beta value of each molecule
+  std::vector<double> beta;  //beta value of each atom
+  std::vector<double> occ;  //occ value of each atom
   std::vector<uint> box;
   std::vector<std::string> resNames;
   bool restart, firstResInFile, recalcTrajectory;
@@ -143,6 +145,7 @@ public:
       ar & y;
       ar & z;
       ar & beta;
+      ar & occ;
       ar & box;
       ar & resNames;
       ar & restart;


### PR DESCRIPTION
The occupancy column of PDB restart files is currently being zero'ed out no matter what.  This PR adjusts the behavior to print whatever the occupancy of that atom was at the start of the simulation.  Note, the PDB trajectories still replace the occupancy column with the box id that atom occupies.  This PR only changes restart PDB occ column.  

This will allow pyMCMD users to group atoms to form col vars using the occ column as a reference.  Also, the occ column could be used for continuing Free Energy calculations in namd, by using the occ column as lambda

Example run.  Changed the occ of atom 1 from 0.0 to 4.0;  The occ stays 4.0 after the first run and after continuing from checkpoint.
[val.zip](https://github.com/GOMC-WSU/GOMC/files/7866715/val.zip)
.