### PR TITLE
Fix #414 GOMC prints console headers twice when printing every step

### DIFF
--- a/src/ConsoleOutput.cpp
+++ b/src/ConsoleOutput.cpp
@@ -20,7 +20,7 @@ along with this program, also can be found at <http://www.gnu.org/licenses/>.
 void ConsoleOutput::DoOutput(const ulong step)
 {
   GOMC_EVENT_START(1, GomcProfileEvent::CONSOLE_OUTPUT);
-  if (step == 0) {
+  if (WriteConsoleHeaders) {
     std::cout << std::endl << "################################################################################" << std::endl;
     std::cout << "########################## INITIAL SIMULATION ENERGY ###########################" << std::endl << std::endl;
 
@@ -28,7 +28,7 @@ void ConsoleOutput::DoOutput(const ulong step)
     std::cout << std::endl;
 
     for (uint b = 0; b < BOX_TOTAL; b++) {
-      PrintEnergy(b, var->energyRef[b], -1);
+      PrintEnergy(b, var->energyRef[b], step-1);
       std::cout <<  std::endl;
     }
 
@@ -37,7 +37,7 @@ void ConsoleOutput::DoOutput(const ulong step)
       std::cout << std::endl;
 
       for (uint b = 0; b < BOX_TOTAL; b++) {
-        PrintStatistic(b, -1);
+        PrintStatistic(b, step-1);
         std::cout << std::endl;
       }
     }
@@ -60,7 +60,9 @@ void ConsoleOutput::DoOutput(const ulong step)
       PrintStatisticTitle();
       std::cout << std::endl;
     }
-  } else {
+    WriteConsoleHeaders = false;
+  }
+  else {
     for(uint b = 0; b < BOX_TOTAL; b++) {
       if(!forceOutput) {
         PrintMove(b, step);
@@ -83,7 +85,6 @@ void ConsoleOutput::DoOutput(const ulong step)
       }
 
     }
-
   }
   GOMC_EVENT_STOP(1, GomcProfileEvent::CONSOLE_OUTPUT);
 }
@@ -476,14 +477,14 @@ void ConsoleOutput::PrintMoveTitle()
 }
 
 void ConsoleOutput::printElement(const double t, const int width,
-                                 uint percision) const
+                                 uint precision) const
 {
   const char separator = ' ';
   if(std::abs(t) > 1e99) {
-    std::cout << std::right << std::scientific << std::setprecision(percision - 1) <<
+    std::cout << std::right << std::scientific << std::setprecision(precision - 1) <<
               std::setw(width) << std::setfill(separator) << t;
   } else {
-    std::cout << std::right << std::scientific << std::setprecision(percision) <<
+    std::cout << std::right << std::scientific << std::setprecision(precision) <<
               std::setw(width) << std::setfill(separator) << t;
   }
 

--- a/src/ConsoleOutput.h
+++ b/src/ConsoleOutput.h
@@ -62,6 +62,7 @@ public:
         enableSurfTension) {
       enableStat = true;
     }
+    WriteConsoleHeaders = true;
     DoOutput(0);
   }
   virtual void DoOutput(const ulong step);
@@ -70,6 +71,7 @@ private:
   const static int elementWidth = 16;
   bool enableEnergy, enablePressure, enableDens, enableVolume, enableMol;
   bool enableSurfTension, enableStat;
+  bool WriteConsoleHeaders;
   void PrintMove(const uint box, const ulong step) const;
   void PrintMoveStat(const uint box, const ulong step) const;
   void PrintStatistic(const uint box, const ulong step) const;
@@ -78,9 +80,9 @@ private:
   void PrintEnergyTitle();
   void PrintStatisticTitle();
   void PrintMoveTitle();
-  void printElement (const double t, const int width, uint percision = 4) const;
-  void printElement (const uint t, const int width) const;
-  void printElement (const std::string t, const int width) const;
+  void printElement(const double t, const int width, uint precision = 4) const;
+  void printElement(const uint t, const int width) const;
+  void printElement(const std::string t, const int width) const;
 
   template <typename T> void printElementStep ( const T t, const ulong step,
       const int width) const;


### PR DESCRIPTION
This is a small patch that prevents the console headers from printing twice when the output is printed every step. Added a boolean variable so that the headers are printed only the first time, instead of using step==0 as a special value.