### PR TITLE
Made OCC PR a template

### DIFF
--- a/src/PDBOutput.cpp
+++ b/src/PDBOutput.cpp
@@ -291,30 +291,10 @@ void PDBOutput::PrintCrystRest(const uint b, const ulong step, Writer & out)
   out.file << outStr << std::endl;
 }
 
-// Restart PDB
-void PDBOutput::InsertAtomInLine(std::string & line, XYZ const& coor,
-                                 double const& occ,
-                                 double const& beta)
-{
-  using namespace pdb_entry::atom::field;
-  using namespace pdb_entry;
-  sstrm::Converter toStr;
-  //Fill in particle's stock string with new x, y, z, and occupancy
-  toStr.Fixed().Align(x::ALIGN).Precision(x::PRECISION);
-  toStr.Replace(line, coor.x, x::POS);
-  toStr.Fixed().Align(y::ALIGN).Precision(y::PRECISION);
-  toStr.Replace(line, coor.y, y::POS);
-  toStr.Fixed().Align(z::ALIGN).Precision(z::PRECISION);
-  toStr.Replace(line, coor.z, z::POS);
-  toStr.Align(occupancy::ALIGN);
-  toStr.Replace(line, occ, occupancy::POS);
-  toStr.Align(beta::ALIGN);
-  toStr.Replace(line, beta, beta::POS);
-}
-
 // PDB trajectory
+template <typename T>
 void PDBOutput::InsertAtomInLine(std::string & line, XYZ const& coor,
-                                 std::string const& occ,
+                                 const T &occ,
                                  double const& beta)
 {
   using namespace pdb_entry::atom::field;

--- a/src/PDBOutput.h
+++ b/src/PDBOutput.h
@@ -69,11 +69,9 @@ private:
                   const char chain, std::string const& atomAlias,
                   std::string const& resName);
 
+template <typename T>
   void InsertAtomInLine(std::string & line, XYZ const& coor,
-                        std::string const& occ, double const& beta);
-
-  void InsertAtomInLine(std::string & line, XYZ const& coor,
-                        double const& occ, double const& beta);
+                        const T &occ, double const& beta);
 
   void PrintEnd(Writer & out)
   {


### PR DESCRIPTION
I forgot to push my last commit before merging the occupancy PR.  I converted the restart and pdb trajectory InsertAtomInLine methods to one method with a templated parameter

Validation attached.
[Base.zip](https://github.com/GOMC-WSU/GOMC/files/7886181/Base.zip)
.