### PR TITLE
Add support for Impulse Pressure Correction (IPC)

### DIFF
--- a/src/CalculateEnergy.cpp
+++ b/src/CalculateEnergy.cpp
@@ -569,7 +569,7 @@ reduction(+:vT11, vT12, vT13, vT22, vT23, vT33, rT11, rT12, rT13, rT22, rT23, rT
 
   GOMC_EVENT_STOP(1, GomcProfileEvent::EN_BOX_VIRIAL);
 
-  if (forcefield.useLRC) {
+  if (forcefield.useLRC || forcefield.useIPC) {
     VirialCorrection(tempVir, currentAxes, box);
   }
 

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -158,7 +158,7 @@ struct VDWSwitch : public PotentialConfig {
 struct FFValues {
   uint VDW_KIND;
   double cutoff, cutoffLow, rswitch;
-  bool doTailCorr, vdwGeometricSigma;
+  bool doTailCorr, vdwGeometricSigma, doImpulsePressureCorr;
   std::string kind;
 
   static const std::string VDW, VDW_SHIFT, VDW_SWITCH, VDW_EXP6;

--- a/src/FFExp6.h
+++ b/src/FFExp6.h
@@ -79,6 +79,9 @@ public:
   //!!Returns virial correction
   virtual double VirialLRC(const uint kind1, const uint kind2) const;
 
+  //!Returns impulse pressure correction term for a kind pair
+  virtual double ImpulsePressureCorrection(const uint kind1, const uint kind2) const;
+
   //Calculate the dE/dlambda for vdw energy
   virtual double CalcdEndL(const double distSq, const uint kind1,
                            const uint kind2, const
@@ -412,6 +415,19 @@ inline double FF_EXP6::VirialLRC(const uint kind1, const uint kind2) const
                             (6.0 * B * B * B + 6.0 * B * B * rCut +
                              3.0 * rCut * rCut * B + rCut * rCut * rCut) -
                             2.0 * C / (rCut * rCut * rCut));
+  return tc;
+}
+
+inline double FF_EXP6::ImpulsePressureCorrection(const uint kind1, const uint kind2) const
+{
+  uint idx = FlatIndex(kind1, kind2);
+  double rCut = forcefield.rCut;
+  double rCut3 = rCut * forcefield.rCutSq;
+  double A = 6.0 * epsilon[idx] * exp(n[idx]) / ((double)n[idx] - 6.0);
+  double B = -1.0 * (double)n[idx] / rMin[idx];
+  double C = epsilon[idx] * (double)n[idx] *  pow(rMin[idx], 6.0) /
+             ((double)n[idx] - 6.0);
+  double tc = 2.0 * M_PI * (A * exp(rCut * B) * rCut3 - C / rCut3);
   return tc;
 }
 

--- a/src/FFParticle.cpp
+++ b/src/FFParticle.cpp
@@ -139,6 +139,18 @@ double FFParticle::VirialLRC(const uint kind1, const uint kind2) const
   return tc;
 }
 
+double FFParticle::ImpulsePressureCorrection(const uint kind1, const uint kind2) const
+{
+  uint idx = FlatIndex(kind1, kind2);
+  double tc = 1.0;
+  double sigma = sqrt(sigmaSq[idx]);
+  double rRat = sigma / forcefield.rCut;
+  double N = (double)(n[idx]);
+  tc *= 2.0 * M_PI * epsilon_cn[idx] * forcefield.rCutSq * forcefield.rCut ;
+  tc *= (pow(rRat, N) - pow(rRat, 6.0));
+  return tc;
+}
+
 void FFParticle::Blend(ff_setup::Particle const& mie)
 {
   for(uint i = 0; i < count; ++i) {

--- a/src/FFParticle.h
+++ b/src/FFParticle.h
@@ -86,6 +86,8 @@ public:
   virtual double EnergyLRC(const uint kind1, const uint kind2) const;
   //!Returns Energy long-range correction term for a kind pair
   virtual double VirialLRC(const uint kind1, const uint kind2) const;
+  //!Returns impulse pressure correction term for a kind pair
+  virtual double ImpulsePressureCorrection(const uint kind1, const uint kind2) const;
 
   //Calculate the dE/dlambda for vdw energy
   virtual double CalcdEndL(const double distSq, const uint kind1,

--- a/src/FFShift.h
+++ b/src/FFShift.h
@@ -70,6 +70,11 @@ public:
   {
     return 0.0;
   }
+  //!Returns zero for impulse pressure correction term for a kind pair
+  virtual double ImpulsePressureCorrection(const uint kind1, const uint kind2) const
+  {
+    return 0.0;
+  }
 
   //Calculate the dE/dlambda for vdw energy
   virtual double CalcdEndL(const double distSq, const uint kind1,

--- a/src/FFSwitch.h
+++ b/src/FFSwitch.h
@@ -79,6 +79,11 @@ public:
   {
     return 0.0;
   }
+  //!Returns zero for impulse pressure correction term for a kind pair
+  virtual double ImpulsePressureCorrection(const uint kind1, const uint kind2) const
+  {
+    return 0.0;
+  }
 
   //Calculate the dE/dlambda for vdw energy
   virtual double CalcdEndL(const double distSq, const uint kind1,

--- a/src/FFSwitchMartini.h
+++ b/src/FFSwitchMartini.h
@@ -104,6 +104,11 @@ public:
   {
     return 0.0;
   }
+  //!Returns zero for impulse pressure correction term for a kind pair
+  virtual double ImpulsePressureCorrection(const uint kind1, const uint kind2) const
+  {
+    return 0.0;
+  }
 
   //Calculate the dE/dlambda for vdw energy
   virtual double CalcdEndL(const double distSq, const uint kind1,

--- a/src/Forcefield.cpp
+++ b/src/Forcefield.cpp
@@ -45,6 +45,7 @@ void Forcefield::InitBasicVals(config_setup::SystemVals const& val,
                                config_setup::FFKind const& ffKind)
 {
   useLRC = val.ff.doTailCorr;
+  useIPC = val.ff.doImpulsePressureCorr;
   T_in_K = val.T.inKelvin;
   rCut = val.ff.cutoff;
   rCutSq = rCut * rCut;

--- a/src/Forcefield.h
+++ b/src/Forcefield.h
@@ -42,6 +42,7 @@ public:
   FFAngles * angles;              //!<For 3-atom bending energy
   FFDihedrals dihedrals;          //!<For 4-atom torsional rotation energy
   bool useLRC;                    //!<Use long-range tail corrections if true
+  bool useIPC;                    //!<Use impulse pressure corrections if true
   double T_in_K;                  //!<System temp in Kelvin
   double beta;                    //!<Thermodynamic beta = 1/(T) K^-1)
   double rCut, rCutSq;            //!<Cutoff radius for LJ/Mie potential (angstroms)

--- a/src/Molecules.cpp
+++ b/src/Molecules.cpp
@@ -151,25 +151,45 @@ void Molecules::Init(Setup & setup, Forcefield & forcefield,
   //Pair Correction matrices
   pairEnCorrections = new double[kindsCount * kindsCount];
   pairVirCorrections = new double[kindsCount * kindsCount];
-  for(uint i = 0; i < kindsCount; ++i) {
-    for(uint j = i; j < kindsCount; ++j) {
-      pairEnCorrections[i * kindsCount + j] = 0.0;
-      pairVirCorrections[i * kindsCount + j] = 0.0;
-      for(uint pI = 0; pI < kinds[i].NumAtoms(); ++pI) {
-        for(uint pJ = 0; pJ < kinds[j].NumAtoms(); ++pJ) {
-          pairEnCorrections[i * kindsCount + j] +=
-            forcefield.particles->EnergyLRC(kinds[i].AtomKind(pI),
-                                            kinds[j].AtomKind(pJ));
-          pairVirCorrections[i * kindsCount + j] +=
-            forcefield.particles->VirialLRC(kinds[i].AtomKind(pI),
-                                            kinds[j].AtomKind(pJ));
+  // Initial with zero
+  std::fill_n(pairEnCorrections, kindsCount * kindsCount, 0.0);
+  std::fill_n(pairVirCorrections, kindsCount * kindsCount, 0.0);
+
+  if (forcefield.useLRC) {
+    for(uint i = 0; i < kindsCount; ++i) {
+      for(uint j = i; j < kindsCount; ++j) {
+        for(uint pI = 0; pI < kinds[i].NumAtoms(); ++pI) {
+          for(uint pJ = 0; pJ < kinds[j].NumAtoms(); ++pJ) {
+            pairEnCorrections[i * kindsCount + j] +=
+              forcefield.particles->EnergyLRC(kinds[i].AtomKind(pI),
+                                              kinds[j].AtomKind(pJ));
+            pairVirCorrections[i * kindsCount + j] +=
+              forcefield.particles->VirialLRC(kinds[i].AtomKind(pI),
+                                              kinds[j].AtomKind(pJ));
+          }
         }
+        //set other side of the diagonal
+        pairEnCorrections[j * kindsCount + i] =
+          pairEnCorrections[i * kindsCount + j];
+        pairVirCorrections[j * kindsCount + i] =
+          pairVirCorrections[i * kindsCount + j];
       }
-      //set other side of the diagonal
-      pairEnCorrections[j * kindsCount + i] =
-        pairEnCorrections[i * kindsCount + j];
-      pairVirCorrections[j * kindsCount + i] =
-        pairVirCorrections[i * kindsCount + j];
+    }
+  } else if (forcefield.useIPC) {
+    for(uint i = 0; i < kindsCount; ++i) {
+      for(uint j = i; j < kindsCount; ++j) {
+        for(uint pI = 0; pI < kinds[i].NumAtoms(); ++pI) {
+          for(uint pJ = 0; pJ < kinds[j].NumAtoms(); ++pJ) {
+            // There is no Impulse energy term. Just Pressure
+            pairVirCorrections[i * kindsCount + j] +=
+              forcefield.particles->ImpulsePressureCorrection(kinds[i].AtomKind(pI),
+                                                              kinds[j].AtomKind(pJ));
+          }
+        }
+        //set other side of the diagonal
+        pairVirCorrections[j * kindsCount + i] =
+          pairVirCorrections[i * kindsCount + j];
+      }
     }
   }
 }


### PR DESCRIPTION
Add support for Impulse Pressure Correction (IPC) for truncated potential (e.g. Mie and Exp-6) that does not utilize any long range correction (LRC). 

IPC only add correction term to pressure calculation and unlike LRC, it has no effect on energy.

### How to use:
Simply include `IPC  true` keyword into your config file.

**Note:** You can only use this feature if  `LRC  false`