### PR TITLE
Fix #421 GOMC terminates on input Checkpoint False

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -2314,7 +2314,7 @@ void ConfigSetup::verifyInputs(void)
     std::cout << "Error: Restart coordinate frequency is not specified!\n";
     exit(EXIT_FAILURE);
   }
-  if(in.files.checkpoint.defined[0] && in.files.checkpoint.name[0] == "") {
+  if(in.restart.restartFromCheckpoint && in.files.checkpoint.name[0] == "") {
     std::cout << "Error: Restart from checkpoint requested but checkpoint filename is not specified!\n";
     exit(EXIT_FAILURE);
   } 

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -905,6 +905,7 @@ private:
   int stringtoi(const std::string& s);
   double stringtod(const std::string& s);
   bool checkBool(std::string str);
+  bool isBool(std::string str);
   bool CheckString(std::string str1, std::string str2);
   void verifyInputs(void);
   InputFileReader reader;


### PR DESCRIPTION
GOMC terminates if the config file includes the line

Checkpoint False

with the error message that the checkpoint file "False" cannot be opened.

The patch tests the input when Checkpoint has only one parameter. When it is a boolean string, like False or On, then the parameter is not interpreted as a filename. If the parameter is not a boolean string, then it is interpreted as the checkpoint filename.

The patch tests for the case and terminates if "Checkpoint True" is entered without providing the filename.