### PR TITLE
Fix some minor issue in Multiparticle and brownian like Multiparticle

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -1776,7 +1776,8 @@ void ConfigSetup::verifyInputs(void)
     sys.ff.doTailCorr = false;
   }
   if(((sys.ff.VDW_KIND == sys.ff.VDW_STD_KIND) ||
-      (sys.ff.VDW_KIND == sys.ff.VDW_EXP6_KIND)) && (sys.ff.doImpulsePressureCorr == false)) {
+      (sys.ff.VDW_KIND == sys.ff.VDW_EXP6_KIND)) && 
+      (!sys.ff.doImpulsePressureCorr && !sys.ff.doTailCorr)) {
     std::cout << "Warning: Impulse Pressure Correction is Inactive for " <<
               "Non-truncated potential." << std::endl;
   }

--- a/src/moves/MultiParticle.h
+++ b/src/moves/MultiParticle.h
@@ -229,6 +229,7 @@ inline uint MultiParticle::Prep(const double subDraw, const double movPerc)
   molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
   atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
   molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  molTorqueRef.CopyRange(molTorqueNew, 0, 0, molTorqueNew.Count());
   #endif
 
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE);
@@ -284,6 +285,7 @@ inline uint MultiParticle::PrepNEMTMC(const uint box, const uint midx, const uin
   molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
   atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
   molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  molTorqueRef.CopyRange(molTorqueNew, 0, 0, molTorqueNew.Count());
   #endif
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE);
   return state;

--- a/src/moves/MultiParticle.h
+++ b/src/moves/MultiParticle.h
@@ -215,17 +215,22 @@ inline uint MultiParticle::Prep(const double subDraw, const double movPerc)
     calcEnRef.BoxForce(sysPotRef, coordCurrRef, atomForceRef, molForceRef,
                        boxDimRef, bPick);
 
-    if(moveType == mp::MPROTATE) {
-      //Calculate Torque for old positions
-      calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
-                                atomForceRef, atomForceRecRef, molTorqueRef, bPick);
-    }
+    //Calculate Torque for old positions
+    calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
+                              atomForceRef, atomForceRecRef, molTorqueRef, bPick);
 
     sysPotRef.Total();
     GOMC_EVENT_STOP(1, GomcProfileEvent::CALC_EN_MULTIPARTICLE);
   }
   coordCurrRef.CopyRange(newMolsPos, 0, 0, coordCurrRef.Count());
   comCurrRef.CopyRange(newCOMs, 0, 0, comCurrRef.Count());
+  #if ENSEMBLE == GCMC || ENSEMBLE == GEMC
+  atomForceRef.CopyRange(atomForceNew, 0, 0, atomForceNew.Count());
+  molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
+  atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
+  molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  #endif
+
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE);
   return state;
 }
@@ -266,16 +271,20 @@ inline uint MultiParticle::PrepNEMTMC(const uint box, const uint midx, const uin
     calcEnRef.BoxForce(sysPotRef, coordCurrRef, atomForceRef, molForceRef,
                        boxDimRef, bPick);
 
-    if(moveType == mp::MPROTATE) {
-      //Calculate Torque for old positions
-      calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
-                                atomForceRef, atomForceRecRef, molTorqueRef, bPick);
-    }
+    //Calculate Torque for old positions
+    calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
+                              atomForceRef, atomForceRecRef, molTorqueRef, bPick);
 
     sysPotRef.Total();
   }
   coordCurrRef.CopyRange(newMolsPos, 0, 0, coordCurrRef.Count());
   comCurrRef.CopyRange(newCOMs, 0, 0, comCurrRef.Count());
+  #if ENSEMBLE == GCMC || ENSEMBLE == GEMC
+  atomForceRef.CopyRange(atomForceNew, 0, 0, atomForceNew.Count());
+  molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
+  atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
+  molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  #endif
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE);
   return state;
 }
@@ -349,11 +358,10 @@ inline void MultiParticle::CalcEn()
   calcEwald->BoxForceReciprocal(newMolsPos, atomForceRecNew, molForceRecNew,
                                 bPick);
 
-  if(moveType == mp::MPROTATE) {
-    //Calculate Torque for new positions
-    calcEnRef.CalculateTorque(moleculeIndex, newMolsPos, newCOMs, atomForceNew,
-                              atomForceRecNew, molTorqueNew, bPick);
-  }
+  //Calculate Torque for new positions
+  calcEnRef.CalculateTorque(moleculeIndex, newMolsPos, newCOMs, atomForceNew,
+                            atomForceRecNew, molTorqueNew, bPick);
+  
   GOMC_EVENT_STOP(1, GomcProfileEvent::CALC_EN_MULTIPARTICLE);
 }
 
@@ -443,9 +451,7 @@ inline void MultiParticle::Accept(const uint rejectState, const ulong step)
     swap(atomForceRef, atomForceNew);
     swap(molForceRecRef, molForceRecNew);
     swap(atomForceRecRef, atomForceRecNew);
-    // molTorqueRef is computed only for rotate move
-    if (moveType == mp::MPROTATE)
-      swap(molTorqueRef, molTorqueNew);
+    swap(molTorqueRef, molTorqueNew);
     // Update reciprocal value
     calcEwald->UpdateRecip(bPick);
     // Update the velocity in box

--- a/src/moves/MultiParticleBrownianMotion.h
+++ b/src/moves/MultiParticleBrownianMotion.h
@@ -207,6 +207,7 @@ inline uint MultiParticleBrownian::Prep(const double subDraw, const double movPe
   molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
   atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
   molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  molTorqueRef.CopyRange(molTorqueNew, 0, 0, molTorqueNew.Count());
   #endif
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE_BM);
   return state;
@@ -260,6 +261,7 @@ inline uint MultiParticleBrownian::PrepNEMTMC(const uint box, const uint midx, c
   molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
   atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
   molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  molTorqueRef.CopyRange(molTorqueNew, 0, 0, molTorqueNew.Count());
   #endif
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE_BM);
   return state;

--- a/src/moves/MultiParticleBrownianMotion.h
+++ b/src/moves/MultiParticleBrownianMotion.h
@@ -193,17 +193,21 @@ inline uint MultiParticleBrownian::Prep(const double subDraw, const double movPe
     calcEnRef.BoxForce(sysPotRef, coordCurrRef, atomForceRef, molForceRef,
                        boxDimRef, bPick);
 
-    if(moveType == mp::MPROTATE) {
-      //Calculate Torque for old positions
-      calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
-                                atomForceRef, atomForceRecRef, molTorqueRef, bPick);
-    }
+    //Calculate Torque for old positions
+    calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
+                              atomForceRef, atomForceRecRef, molTorqueRef, bPick);
 
     sysPotRef.Total();
     GOMC_EVENT_STOP(1, GomcProfileEvent::CALC_EN_MULTIPARTICLE_BM);
   }
   coordCurrRef.CopyRange(newMolsPos, 0, 0, coordCurrRef.Count());
   comCurrRef.CopyRange(newCOMs, 0, 0, comCurrRef.Count());
+  #if ENSEMBLE == GCMC || ENSEMBLE == GEMC
+  atomForceRef.CopyRange(atomForceNew, 0, 0, atomForceNew.Count());
+  molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
+  atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
+  molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  #endif
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE_BM);
   return state;
 }
@@ -243,16 +247,20 @@ inline uint MultiParticleBrownian::PrepNEMTMC(const uint box, const uint midx, c
     calcEnRef.BoxForce(sysPotRef, coordCurrRef, atomForceRef, molForceRef,
                        boxDimRef, bPick);
 
-    if(moveType == mp::MPROTATE) {
       //Calculate Torque for old positions
       calcEnRef.CalculateTorque(moleculeIndex, coordCurrRef, comCurrRef,
                                 atomForceRef, atomForceRecRef, molTorqueRef, bPick);
-    }
 
     sysPotRef.Total();
   }
   coordCurrRef.CopyRange(newMolsPos, 0, 0, coordCurrRef.Count());
   comCurrRef.CopyRange(newCOMs, 0, 0, comCurrRef.Count());
+  #if ENSEMBLE == GCMC || ENSEMBLE == GEMC
+  atomForceRef.CopyRange(atomForceNew, 0, 0, atomForceNew.Count());
+  molForceRef.CopyRange(molForceNew, 0, 0, molForceNew.Count());
+  atomForceRecRef.CopyRange(atomForceRecNew, 0, 0, atomForceRecNew.Count());
+  molForceRecRef.CopyRange(molForceRecNew, 0, 0, molForceRecNew.Count());
+  #endif
   GOMC_EVENT_STOP(1, GomcProfileEvent::PREP_MULTIPARTICLE_BM);
   return state;
 }
@@ -354,11 +362,10 @@ inline void MultiParticleBrownian::CalcEn()
   calcEwald->BoxForceReciprocal(newMolsPos, atomForceRecNew, molForceRecNew,
                                 bPick);
 
-  if(moveType == mp::MPROTATE) {
-    //Calculate Torque for new positions
-    calcEnRef.CalculateTorque(moleculeIndex, newMolsPos, newCOMs, atomForceNew,
-                              atomForceRecNew, molTorqueNew, bPick);
-  }
+  //Calculate Torque for new positions
+  calcEnRef.CalculateTorque(moleculeIndex, newMolsPos, newCOMs, atomForceNew,
+                            atomForceRecNew, molTorqueNew, bPick);
+  
   sysPotNew.Total();
   GOMC_EVENT_STOP(1, GomcProfileEvent::CALC_EN_MULTIPARTICLE);
 }


### PR DESCRIPTION
1. Fix some warning output for IPC calculation.
2. Copy the atom force, mol force, and mol torque from reference variable to new variable when we simulating system with more than 1 box (GCMC and GEMC). 
3. Fix torque calculation to only override the value of the molecule index we are operating on.
4. Fix some warning output for IPC calculation.
