### PR TITLE
Fix #425 use the correct recip energy for IntraMEMC move acceptance

### DIFF
--- a/src/moves/IntraMoleculeExchange1.h
+++ b/src/moves/IntraMoleculeExchange1.h
@@ -495,7 +495,8 @@ inline void IntraMoleculeExchange1::CalcEn()
   correctDiff = 0.0;
 
   if(!overlap) {
-    //recipDiff is the running total, so it accumulates with each call. Only need the last.
+    //MolExchangeReciprocal returns the total change in recip energy. It accumulates with each
+    //call, so we should use only the last of the two.
     recipDiff = calcEwald->MolExchangeReciprocal(newMolA, oldMolA, molIndexA, molIndexA, true);
     recipDiff = calcEwald->MolExchangeReciprocal(newMolB, oldMolB, molIndexB, molIndexB, false);
 

--- a/src/moves/IntraMoleculeExchange2.h
+++ b/src/moves/IntraMoleculeExchange2.h
@@ -342,7 +342,7 @@ inline uint IntraMoleculeExchange2::Transform()
 
 inline void IntraMoleculeExchange2::CalcEn()
 {
-  // Updates recipDiffA and recipDiffB and updates sum new arrays at the same time
+  // Updates recipDiff and updates sum new arrays at the same time
   IntraMoleculeExchange1::CalcEn();
 }
 

--- a/src/moves/IntraMoleculeExchange3.h
+++ b/src/moves/IntraMoleculeExchange3.h
@@ -305,6 +305,8 @@ inline void IntraMoleculeExchange3::CalcEn()
       correctDiff += calcEwald->SwapCorrection(newMolB[n], molIndexB[n]);
       correctDiff -= calcEwald->SwapCorrection(oldMolB[n], molIndexB[n]);
     }
+    //MolExchangeReciprocal returns the total change in recip energy. It accumulates with each
+    //call, so we should use only the last of the two.
     recipDiff = calcEwald->MolExchangeReciprocal(newMolA, oldMolA, molIndexA, molIndexA, true);
     recipDiff = calcEwald->MolExchangeReciprocal(newMolB, oldMolB, molIndexB, molIndexB, false);
 

--- a/src/moves/IntraMoleculeExchange3.h
+++ b/src/moves/IntraMoleculeExchange3.h
@@ -296,7 +296,7 @@ inline void IntraMoleculeExchange3::CalcEn()
 {
   GOMC_EVENT_START(1, GomcProfileEvent::CALC_EN_INTRA_MEMC);
   W_recip = 1.0;
-  recipDiffA = 0.0, recipDiffB = 0.0;
+  recipDiff = 0.0;
   correctDiff = 0.0;
   //No need to calculate the correction term for kindS since it is
   // inserted rigid body. We just need it for kindL
@@ -305,11 +305,10 @@ inline void IntraMoleculeExchange3::CalcEn()
       correctDiff += calcEwald->SwapCorrection(newMolB[n], molIndexB[n]);
       correctDiff -= calcEwald->SwapCorrection(oldMolB[n], molIndexB[n]);
     }
-    recipDiffA = calcEwald->MolExchangeReciprocal(newMolA, oldMolA, molIndexA, molIndexA, true);
-    recipDiffB = calcEwald->MolExchangeReciprocal(newMolB, oldMolB, molIndexB, molIndexB, false);
+    recipDiff = calcEwald->MolExchangeReciprocal(newMolA, oldMolA, molIndexA, molIndexA, true);
+    recipDiff = calcEwald->MolExchangeReciprocal(newMolB, oldMolB, molIndexB, molIndexB, false);
 
-    W_recip = exp(-1.0 * ffRef.beta * (recipDiffA + recipDiffB +
-                                       correctDiff));
+    W_recip = exp(-ffRef.beta * (recipDiff + correctDiff));
   }
   GOMC_EVENT_STOP(1, GomcProfileEvent::CALC_EN_INTRA_MEMC);
 }


### PR DESCRIPTION
This patch fixes the bug that resulted in the acceptance term for the IntraMEMC moves using the wrong change in reciprocal energy.

This could result in accepting some moves that should not have been accepted or rejecting some moves that should have been accepted. The energy was updated correctly.

Fixes issue #425  for a bug that was introduced in the fix for issue #234.