### PR TITLE
Add #include <stdint.h> to Endian.h

### DIFF
--- a/lib/Endian.h
+++ b/lib/Endian.h
@@ -37,6 +37,7 @@
  */
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #define bswap_64(x)                            \
   ((((x) & 0xff00000000000000ull) >> 56)       \


### PR DESCRIPTION
Tests don't build without this include statement.