### PR TITLE
Update ConfigSetup.cpp

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -1982,7 +1982,7 @@ void ConfigSetup::verifyInputs(void)
   }
 
   if(!sys.volume.hasVolume && !in.restart.enable) {
-    std::cout << "Error: This simulation requires to define " << 3 * BOX_TOTAL <<
+    std::cout << "Error: This simulation requires the user define " << 3 * BOX_TOTAL <<
               " Cell Basis vectors!" << std::endl;
     for(uint b = 0; b < BOX_TOTAL; b++) {
       for(uint i = 0; i < 3; i++) {


### PR DESCRIPTION
Fixed error message for when cell basis vectors are required, but not defined in the input file. 