### PR TITLE
Adds the CheckpointFreq option

### DIFF
--- a/src/BoxDimensions.cpp
+++ b/src/BoxDimensions.cpp
@@ -19,34 +19,9 @@ void BoxDimensions::Init(config_setup::RestartSettings const& restart,
     rCut[b] = std::max(ff.rCut, ff.rCutCoulomb[b]);
     rCutSq[b] = rCut[b] * rCut[b];
     minVol[b] = 8.0 * rCutSq[b] * rCut[b] + 0.001;
-    if(restart.enable && cryst.hasVolume[b]) {
-      axis = cryst.axis;
-      double alpha = cos(cryst.cellAngle[b][0] * M_PI / 180.0);
-      double beta  = cos(cryst.cellAngle[b][1] * M_PI / 180.0);
-      double gamma = cos(cryst.cellAngle[b][2] * M_PI / 180.0);
-      if(float(cryst.cellAngle[b][0]) == 90.0)
-        alpha = 0.0;
-      if(float(cryst.cellAngle[b][1]) == 90.0)
-        beta = 0.0;
-      if(float(cryst.cellAngle[b][2]) == 90.0)
-        gamma = 0.0;
-      double cosBSq = beta * beta;
-      double cosGSq = gamma * gamma;
-      double temp = (alpha - beta * gamma) / (sqrt(1.0 - cosGSq));
-      cellBasis[b].Set(0, 1.0, 0.0, 0.0);
-      cellBasis[b].Set(1, gamma, sqrt(1.0 - cosGSq), 0.0);
-      cellBasis[b].Set(2, beta, temp, sqrt(1.0 - cosBSq - temp * temp));
-      cellBasis[b].Scale(0, axis.Get(b).x);
-      cellBasis[b].Scale(1, axis.Get(b).y);
-      cellBasis[b].Scale(2, axis.Get(b).z);
-    } else if (restart.enable && cryst.hasCellBasis[b]) {
-      cryst.cellBasis[b].CopyRange(cellBasis[b], 0, 0, 3);
-    } else if(confVolume.hasVolume) {
+    // Did this box have cell vectors defined in the conf file?
+    if(confVolume.hasVolume[b]) {
       confVolume.axis[b].CopyRange(cellBasis[b], 0, 0, 3);
-    } else {
-      fprintf(stderr,
-              "Error: Cell Basis not specified in XSC, PDB, or in.conf files.\n");
-      exit(EXIT_FAILURE);
     }
 
     //Print Box dimension info

--- a/src/BoxDimensions.cpp
+++ b/src/BoxDimensions.cpp
@@ -19,10 +19,16 @@ void BoxDimensions::Init(config_setup::RestartSettings const& restart,
     rCut[b] = std::max(ff.rCut, ff.rCutCoulomb[b]);
     rCutSq[b] = rCut[b] * rCut[b];
     minVol[b] = 8.0 * rCutSq[b] * rCut[b] + 0.001;
-    // Did this box have cell vectors defined in the conf file?
-    if(confVolume.hasVolume[b]) {
+    if (restart.restartFromXSCFile && cryst.hasCellBasis[b]) {
+      cryst.cellBasis[b].CopyRange(cellBasis[b], 0, 0, 3);
+    } else if (confVolume.hasVolume) {
       confVolume.axis[b].CopyRange(cellBasis[b], 0, 0, 3);
+    } else {
+      fprintf(stderr,
+              "Error: Cell Basis not specified in XSC, PDB, or in.conf files.\n");
+      exit(EXIT_FAILURE);
     }
+    printf("Box is orthogonal\n");
 
     //Print Box dimension info
     printf("%s %-d: %-26s %6.3f %7.3f %7.3f \n",

--- a/src/BoxDimensionsNonOrth.cpp
+++ b/src/BoxDimensionsNonOrth.cpp
@@ -21,9 +21,16 @@ void BoxDimensionsNonOrth::Init(config_setup::RestartSettings const& restart,
     rCutSq[b] = rCut[b] * rCut[b];
     minVol[b] = 8.0 * rCutSq[b] * rCut[b] + 0.001;
     // Did this box have cell vectors defined in the conf file?
-    if(confVolume.hasVolume[b]) {
+    if (restart.restartFromXSCFile && cryst.hasCellBasis[b]) {
+      cryst.cellBasis[b].CopyRange(cellBasis[b], 0, 0, 3);
+    } else if (confVolume.hasVolume) {
       confVolume.axis[b].CopyRange(cellBasis[b], 0, 0, 3);
+    } else {
+      fprintf(stderr,
+              "Error: Cell Basis not specified in XSC, PDB, or in.conf files.\n");
+      exit(EXIT_FAILURE);
     }
+    printf("Box is non-orthogonal\n");
 
     //Print Box dimension info
     printf("%s %-d: %-26s %6.3f %7.3f %7.3f \n",

--- a/src/BoxDimensionsNonOrth.cpp
+++ b/src/BoxDimensionsNonOrth.cpp
@@ -20,34 +20,9 @@ void BoxDimensionsNonOrth::Init(config_setup::RestartSettings const& restart,
     rCut[b] = std::max(ff.rCut, ff.rCutCoulomb[b]);
     rCutSq[b] = rCut[b] * rCut[b];
     minVol[b] = 8.0 * rCutSq[b] * rCut[b] + 0.001;
-    if(restart.enable && cryst.hasVolume[b]) {
-      axis = cryst.axis;
-      double alpha = cos(cryst.cellAngle[b][0] * M_PI / 180.0);
-      double beta  = cos(cryst.cellAngle[b][1] * M_PI / 180.0);
-      double gamma = cos(cryst.cellAngle[b][2] * M_PI / 180.0);
-      if(float(cryst.cellAngle[b][0]) == 90.0)
-        alpha = 0.0;
-      if(float(cryst.cellAngle[b][1]) == 90.0)
-        beta = 0.0;
-      if(float(cryst.cellAngle[b][2]) == 90.0)
-        gamma = 0.0;
-      double cosBSq = beta * beta;
-      double cosGSq = gamma * gamma;
-      double temp = (alpha - beta * gamma) / (sqrt(1.0 - cosGSq));
-      cellBasis[b].Set(0, 1.0, 0.0, 0.0);
-      cellBasis[b].Set(1, gamma, sqrt(1.0 - cosGSq), 0.0);
-      cellBasis[b].Set(2, beta, temp, sqrt(1.0 - cosBSq - temp * temp));
-      cellBasis[b].Scale(0, axis.Get(b).x);
-      cellBasis[b].Scale(1, axis.Get(b).y);
-      cellBasis[b].Scale(2, axis.Get(b).z);
-    } else if (restart.enable && cryst.hasCellBasis[b]) {
-      cryst.cellBasis[b].CopyRange(cellBasis[b], 0, 0, 3);
-    } else if(confVolume.hasVolume) {
+    // Did this box have cell vectors defined in the conf file?
+    if(confVolume.hasVolume[b]) {
       confVolume.axis[b].CopyRange(cellBasis[b], 0, 0, 3);
-    } else {
-      fprintf(stderr,
-              "Error: Cell Basis not specified in XSC, PDB, or in.conf files.\n");
-      exit(EXIT_FAILURE);
     }
 
     //Print Box dimension info

--- a/src/CheckpointOutput.cpp
+++ b/src/CheckpointOutput.cpp
@@ -29,8 +29,8 @@ CheckpointOutput::CheckpointOutput(System & sys,
 void CheckpointOutput::Init(pdb_setup::Atoms const& atoms,
                             config_setup::Output const& output)
 {
-  enableRestOut = output.restart.settings.enable;
-  stepsRestPerOut = output.restart.settings.frequency;
+  enableRestOut = output.checkpoint.enable;
+  stepsRestPerOut = output.checkpoint.frequency;
   std::string file = output.statistics.settings.uniqueStr.val + "_restart.chk";
 #if GOMC_LIB_MPI
   filename = pathToReplicaOutputDirectory + file;

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -224,9 +224,19 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
     } else if(CheckString(line[0], "FirstStep")) {
       in.restart.step = stringtoi(line[1]);
     } else if(CheckString(line[0], "PRNG")) {
-      in.prng.kind = line[1];
-      if("RANDOM" == line[1])
+      if("RANDOM" == line[1]){
         printf("%-40s %-s \n", "Info: Random seed", "Active");
+        in.prng.kind = line[1];
+      } else if ("INTSEED" == line[1]){ 
+        printf("%-40s %-s \n", "Info: Integer seed", "Active");
+        in.prng.kind = line[1];
+      } else if ("RESTART" == line[1]) {
+        printf("%-40s %-s \n", "Info: Restart seed", "Active");
+        in.prng.kind = line[1];
+      } else {
+        std::cout << "Error: PRNG can be one of three kinds (RANDOM/INTSEED/RESTART)!\n";
+        exit(EXIT_FAILURE);
+      }
     } else if(CheckString(line[0], "PRNG_ParallelTempering")) {
       in.prngParallelTempering.kind = line[1];
       if("RANDOM" == line[1])

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -2529,7 +2529,6 @@ void ConfigSetup::verifyInputs(void)
 
 const std::string config_setup::PRNGKind::KIND_RANDOM = "RANDOM";
 const std::string config_setup::PRNGKind::KIND_SEED = "INTSEED";
-const std::string config_setup::PRNGKind::KIND_RESTART = "RESTART";
 const std::string config_setup::FFKind::FF_CHARMM = "CHARMM";
 const std::string config_setup::FFKind::FF_EXOTIC = "EXOTIC";
 const std::string config_setup::FFKind::FF_MARTINI = "MARTINI";

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -2023,8 +2023,8 @@ void ConfigSetup::verifyInputs(void)
                     " is missing!" << std::endl;
         }
       }
+      exit(EXIT_FAILURE);
     }
-    exit(EXIT_FAILURE);
   }
   if(sys.ff.VDW_KIND == sys.ff.VDW_SWITCH_KIND && sys.ff.rswitch == DBL_MAX) {
     std::cout << "Error: Switch distance is not specified!" << std::endl;

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -96,11 +96,7 @@ struct PRNGKind {
   {
     return str::compare(KIND_SEED, kind);
   }
-  bool IsRestart(void) const
-  {
-    return str::compare(KIND_RESTART, kind);
-  }
-  static const std::string KIND_RANDOM, KIND_SEED, KIND_RESTART;
+  static const std::string KIND_RANDOM, KIND_SEED;
 };
 
 struct FFKind {

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -213,13 +213,14 @@ struct ElectroStatic {
 };
 
 struct Volume {
-  bool hasVolume, cstArea, cstVolBox0;
+  bool hasVolume[BOX_TOTAL], cstArea, cstVolBox0;
   bool readCellBasis[BOX_TOTAL][3];
   XYZArray axis[BOX_TOTAL];
-  Volume(void) : hasVolume(false), cstArea(false), cstVolBox0(false)
+  Volume(void) : cstArea(false), cstVolBox0(false)
   {
     for(uint b = 0; b < BOX_TOTAL; ++b) {
       axis[b] = XYZArray(3);
+      hasVolume[b] = false;
       std::fill_n(readCellBasis[b], 3, false);
     }
   }

--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -93,7 +93,7 @@ public:
   Energy(double intraBond, double nonbond, double inter, double real,
           double recip, double self, double correc) :  
           bond(0.0), angle(0.0), dihedral(0.0), intraBond(intraBond), intraNonbond(nonbond), inter(inter),
-          tc(0.0), total(0.0), real(real), recip(recip), self(self),
+          tailCorrection(0.0), total(0.0), real(real), recip(recip), self(self),
           correction(correc), totalElect(0.0) {}
 
   Energy(double bond, double angle, double dihedral, double intraBond, double nonbond, double inter, double real,

--- a/src/MoveSettings.cpp
+++ b/src/MoveSettings.cpp
@@ -29,7 +29,7 @@ void MoveSettings::Init(StaticVals const& statV,
   totKind = tkind;
   perAdjust = statV.simEventFreq.perAdjust;
   if (!restartFromCheckpoint){
-    for (uint b; b < BOXES_WITH_U_NB; b++) {
+    for (uint b = 0; b < BOXES_WITH_U_NB; b++) {
       SetSingleMoveAccepted(b);
     }    
     for(uint b = 0; b < BOX_TOTAL; b++) {

--- a/src/OutputAbstracts.h
+++ b/src/OutputAbstracts.h
@@ -53,7 +53,7 @@ public:
 
     /* We will output either when the step number is every stepsPerOut
        Or recalculate trajectory is enabled (forceOutput) */
-    /* printOnFirstStep -- only true for PSFOutput */
+    /* printOnFirstStep -- only true for PSFOutput, WolfCalibration */
     if ((printOnFirstStep && step == startStep) || (enableOut && ((step + 1) % stepsPerOut == 0) || forceOutput)) {
       DoOutput(step);
       firstPrint = false;

--- a/src/PRNGSetup.cpp
+++ b/src/PRNGSetup.cpp
@@ -69,10 +69,6 @@ void PRNGSetup::Init(config_setup::RestartSettings const& restart,
     prngMaker.Init();
   else if (genConf.IsSeed())
     prngMaker.Init(genConf.seed);
-  else if (genConf.IsRestart()) {
-    Reader prngSeedFile(name, seedFileAlias);
-    prngMaker.Init(prngSeedFile, restart.step);
-  }
 
   if (prngMaker.prng == NULL)
     prngMaker.HandleError(genConf.kind);

--- a/src/StaticVals.cpp
+++ b/src/StaticVals.cpp
@@ -142,11 +142,7 @@ StaticVals::StaticVals(Setup & set) : intraMemcVal(set.config.sys.intraMemcVal),
 {
   multiParticleEnabled = set.config.sys.moves.multiParticleEnabled;
   isOrthogonal = true;
-  if(set.config.in.restart.enable) {
-    IsBoxOrthogonal(set.pdb.cryst.cellAngle);
-  } else {
-    IsBoxOrthogonal(set.config.sys.volume);
-  }
+  IsBoxOrthogonal(set.config.sys.volume);
 }
 
 

--- a/src/Writer.h
+++ b/src/Writer.h
@@ -18,7 +18,7 @@ class Writer
 {
 public:
   //Init later...
-  Writer() {}
+  Writer() {isOpen = false;}
   //Init now.
   Writer(std::string const& name, std::string const& alias,
          const bool crit = true, const bool note = true)


### PR DESCRIPTION
To allow the user the flexibility of choosing the ability to roughly continue or exactly continue a simulation, RestartFreq and CheckpointFreq are now separate options. However, CheckpointFreq must equal RestartFreq and one cannot use CheckpointFreq without also setting RestartFreq.

The following cases were tested:

Initial Run - Restart False Checkpoint False
[intitialLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144640/intitialLog.txt)
[in.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144641/in.conf.txt)

Continue Initial Run with Restart only - Restart True Checkpoint False; XSC/COOR files provided; Basis vectors removed from conf file
[restBinLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144646/restBinLog.txt)
[rest.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144647/rest.conf.txt)

Continue Initial Run with Restart only - Restart True Checkpoint False; XSC/COOR files not provided; Basis vectors removed from conf file
[restNoBin.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144648/restNoBin.conf.txt)
[restNoBinLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144649/restNoBinLog.txt)

Continue Initial Run with Checkpoint - Restart True Checkpoint True
[chkLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144650/chkLog.txt)
[chk.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144651/chk.conf.txt)

Errors:
Restart False Checkpoint True
[chkErrLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144653/chkErrLog.txt)
[chkErr.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144654/chkErr.conf.txt)
RestartFreq != CheckpointFreq

[freqErrLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144656/freqErrLog.txt)
[freqErr.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144657/freqErr.conf.txt)