### PR TITLE
Adds the CheckpointFreq option

### DIFF
--- a/src/CheckpointOutput.cpp
+++ b/src/CheckpointOutput.cpp
@@ -29,8 +29,8 @@ CheckpointOutput::CheckpointOutput(System & sys,
 void CheckpointOutput::Init(pdb_setup::Atoms const& atoms,
                             config_setup::Output const& output)
 {
-  enableRestOut = output.restart.settings.enable;
-  stepsRestPerOut = output.restart.settings.frequency;
+  enableRestOut = output.checkpoint.enable;
+  stepsRestPerOut = output.checkpoint.frequency;
   std::string file = output.statistics.settings.uniqueStr.val + "_restart.chk";
 #if GOMC_LIB_MPI
   filename = pathToReplicaOutputDirectory + file;

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -230,11 +230,8 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
       } else if ("INTSEED" == line[1]){ 
         printf("%-40s %-s \n", "Info: Integer seed", "Active");
         in.prng.kind = line[1];
-      } else if ("RESTART" == line[1]) {
-        printf("%-40s %-s \n", "Info: Restart seed", "Active");
-        in.prng.kind = line[1];
       } else {
-        std::cout << "Error: PRNG can be one of three kinds (RANDOM/INTSEED/RESTART)!\n";
+        std::cout << "Error: PRNG can be one of three kinds (RANDOM/INTSEED)!\n";
         exit(EXIT_FAILURE);
       }
     } else if(CheckString(line[0], "PRNG_ParallelTempering")) {
@@ -2391,7 +2388,7 @@ void ConfigSetup::verifyInputs(void)
   } 
   
   if((out.checkpoint.enable && out.restart.settings.enable) &&
-    out.checkpoint.frequency % out.restart.settings.frequency != 0){
+    out.checkpoint.frequency != out.restart.settings.frequency){
     std::cout << "Error: Checkpoint frequency must equal restart frequency!\n";
     std::cout << "Example: RestartFreq 1000; CheckpointFreq 10000\n";
     exit(EXIT_FAILURE);

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -2386,7 +2386,7 @@ void ConfigSetup::verifyInputs(void)
   } 
   if((out.checkpoint.enable && out.restart.settings.enable) &&
     out.checkpoint.frequency % out.restart.settings.frequency != 0){
-    std::cout << "Error: Checkpoint frequency must be divisible by restart frequency!\n";
+    std::cout << "Error: Checkpoint frequency must equal restart frequency!\n";
     std::cout << "Example: RestartFreq 1000; CheckpointFreq 10000\n";
     exit(EXIT_FAILURE);
   } 

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -224,9 +224,19 @@ void ConfigSetup::Init(const char *fileName, MultiSim const*const& multisim)
     } else if(CheckString(line[0], "FirstStep")) {
       in.restart.step = stringtoi(line[1]);
     } else if(CheckString(line[0], "PRNG")) {
-      in.prng.kind = line[1];
-      if("RANDOM" == line[1])
+      if("RANDOM" == line[1]){
         printf("%-40s %-s \n", "Info: Random seed", "Active");
+        in.prng.kind = line[1];
+      } else if ("INTSEED" == line[1]){ 
+        printf("%-40s %-s \n", "Info: Integer seed", "Active");
+        in.prng.kind = line[1];
+      } else if ("RESTART" == line[1]) {
+        printf("%-40s %-s \n", "Info: Restart seed", "Active");
+        in.prng.kind = line[1];
+      } else {
+        std::cout << "Error: PRNG can be one of three kinds (RANDOM/INTSEED/RESTART)!\n";
+        exit(EXIT_FAILURE);
+      }
     } else if(CheckString(line[0], "PRNG_ParallelTempering")) {
       in.prngParallelTempering.kind = line[1];
       if("RANDOM" == line[1])

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -1723,6 +1723,11 @@ void ConfigSetup::verifyInputs(void)
     printf("Warning: Cell dimension set, but will be ignored in restart mode.\n");
   }
 
+  if (in.restart.restartFromCheckpoint && !in.restart.enable){
+    std::cout << "Error: Checkpoint cannot be used without Restart true!" << std::endl;
+    exit(EXIT_FAILURE);    
+  }
+
   if(in.prng.kind == "RANDOM" && in.prng.seed != UINT_MAX) {
     printf("Warning: Seed value set, but will be ignored.\n");
   }
@@ -2384,6 +2389,7 @@ void ConfigSetup::verifyInputs(void)
     std::cout << "Error: CheckpointFreq cannot be used without RestartFreq!\n";
     exit(EXIT_FAILURE);
   } 
+  
   if((out.checkpoint.enable && out.restart.settings.enable) &&
     out.checkpoint.frequency % out.restart.settings.frequency != 0){
     std::cout << "Error: Checkpoint frequency must equal restart frequency!\n";

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -2529,7 +2529,6 @@ void ConfigSetup::verifyInputs(void)
 
 const std::string config_setup::PRNGKind::KIND_RANDOM = "RANDOM";
 const std::string config_setup::PRNGKind::KIND_SEED = "INTSEED";
-const std::string config_setup::PRNGKind::KIND_RESTART = "RESTART";
 const std::string config_setup::FFKind::FF_CHARMM = "CHARMM";
 const std::string config_setup::FFKind::FF_EXOTIC = "EXOTIC";
 const std::string config_setup::FFKind::FF_MARTINI = "MARTINI";

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -96,11 +96,7 @@ struct PRNGKind {
   {
     return str::compare(KIND_SEED, kind);
   }
-  bool IsRestart(void) const
-  {
-    return str::compare(KIND_RESTART, kind);
-  }
-  static const std::string KIND_RANDOM, KIND_SEED, KIND_RESTART;
+  static const std::string KIND_RANDOM, KIND_SEED;
 };
 
 struct FFKind {

--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -93,7 +93,7 @@ public:
   Energy(double intraBond, double nonbond, double inter, double real,
           double recip, double self, double correc) :  
           bond(0.0), angle(0.0), dihedral(0.0), intraBond(intraBond), intraNonbond(nonbond), inter(inter),
-          tc(0.0), total(0.0), real(real), recip(recip), self(self),
+          tailCorrection(0.0), total(0.0), real(real), recip(recip), self(self),
           correction(correc), totalElect(0.0) {}
 
   Energy(double bond, double angle, double dihedral, double intraBond, double nonbond, double inter, double real,

--- a/src/ExtendedSystem.cpp
+++ b/src/ExtendedSystem.cpp
@@ -52,6 +52,9 @@ bool ExtendedSystem::operator==(const ExtendedSystem & other){
 void ExtendedSystem::Init(PDBSetup &pdb, Velocity &vel,  config_setup::Input & inputFiles,
                           MoleculeLookup & molLookup, Molecules & mols)
 {
+  if(!inputFiles.restart.enable) {
+    return;
+  }
   // Read the extended system file and update the cellBasis data
   if(inputFiles.restart.restartFromXSCFile) {
     for(int b = 0; b < BOX_TOTAL; b++) {

--- a/src/MoveSettings.cpp
+++ b/src/MoveSettings.cpp
@@ -29,7 +29,7 @@ void MoveSettings::Init(StaticVals const& statV,
   totKind = tkind;
   perAdjust = statV.simEventFreq.perAdjust;
   if (!restartFromCheckpoint){
-    for (uint b; b < BOXES_WITH_U_NB; b++) {
+    for (uint b = 0; b < BOXES_WITH_U_NB; b++) {
       SetSingleMoveAccepted(b);
     }    
     for(uint b = 0; b < BOX_TOTAL; b++) {

--- a/src/OutputAbstracts.h
+++ b/src/OutputAbstracts.h
@@ -53,7 +53,7 @@ public:
 
     /* We will output either when the step number is every stepsPerOut
        Or recalculate trajectory is enabled (forceOutput) */
-    /* printOnFirstStep -- only true for PSFOutput */
+    /* printOnFirstStep -- only true for PSFOutput, WolfCalibration */
     if ((printOnFirstStep && step == startStep) || (enableOut && ((step + 1) % stepsPerOut == 0) || forceOutput)) {
       DoOutput(step);
       firstPrint = false;

--- a/src/PRNGSetup.cpp
+++ b/src/PRNGSetup.cpp
@@ -69,10 +69,6 @@ void PRNGSetup::Init(config_setup::RestartSettings const& restart,
     prngMaker.Init();
   else if (genConf.IsSeed())
     prngMaker.Init(genConf.seed);
-  else if (genConf.IsRestart()) {
-    Reader prngSeedFile(name, seedFileAlias);
-    prngMaker.Init(prngSeedFile, restart.step);
-  }
 
   if (prngMaker.prng == NULL)
     prngMaker.HandleError(genConf.kind);

--- a/src/Writer.h
+++ b/src/Writer.h
@@ -18,7 +18,7 @@ class Writer
 {
 public:
   //Init later...
-  Writer() {}
+  Writer() {isOpen = false;}
   //Init now.
   Writer(std::string const& name, std::string const& alias,
          const bool crit = true, const bool note = true)


### PR DESCRIPTION
To allow the user the flexibility of choosing the ability to roughly continue or exactly continue a simulation, RestartFreq and CheckpointFreq are now separate options. However, CheckpointFreq must equal RestartFreq and one cannot use CheckpointFreq without also setting RestartFreq.

The following cases were tested:

Initial Run - Restart False Checkpoint False
[intitialLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144640/intitialLog.txt)
[in.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144641/in.conf.txt)

Continue Initial Run with Restart only - Restart True Checkpoint False; XSC/COOR files provided; Basis vectors removed from conf file
[restBinLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144646/restBinLog.txt)
[rest.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144647/rest.conf.txt)

Continue Initial Run with Restart only - Restart True Checkpoint False; XSC/COOR files not provided; Basis vectors removed from conf file
[restNoBin.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144648/restNoBin.conf.txt)
[restNoBinLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144649/restNoBinLog.txt)

Continue Initial Run with Checkpoint - Restart True Checkpoint True
[chkLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144650/chkLog.txt)
[chk.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144651/chk.conf.txt)

Errors:
Restart False Checkpoint True
[chkErrLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144653/chkErrLog.txt)
[chkErr.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144654/chkErr.conf.txt)

RestartFreq != CheckpointFreq
[freqErrLog.txt](https://github.com/GOMC-WSU/GOMC/files/9144656/freqErrLog.txt)
[freqErr.conf.txt](https://github.com/GOMC-WSU/GOMC/files/9144657/freqErr.conf.txt)