### PR TITLE
remove bad console entry and increase precision of console outputs to match block output

### DIFF
--- a/src/ConsoleOutput.cpp
+++ b/src/ConsoleOutput.cpp
@@ -307,8 +307,6 @@ void ConsoleOutput::PrintEnergy(const uint box, Energy const& en,
   printElement(en.recip, elementWidth);
   printElement(en.self, elementWidth);
   printElement(en.correction, elementWidth);
-  if (enablePressure)
-    printElement((en.total / var->numByBox[box] + var->pressure[box] * var->volumeRef[box] / var->numByBox[box]) * UNIT_CONST_H::unit::K_TO_KJ_PER_MOL, elementWidth);
   std::cout << std::endl;
 }
 
@@ -331,8 +329,6 @@ void ConsoleOutput::PrintEnergyTitle()
   printElement("RECIP", elementWidth);
   printElement("SELF", elementWidth);
   printElement("CORR", elementWidth);
-  if (enablePressure)
-    printElement("ENTHALPY", elementWidth);
   std::cout << std::endl;
 }
 

--- a/src/ConsoleOutput.h
+++ b/src/ConsoleOutput.h
@@ -68,7 +68,7 @@ public:
   virtual void DoOutput(const ulong step);
   virtual void DoOutputRestart(const ulong step);
 private:
-  const static int elementWidth = 16;
+  const static int elementWidth = 21;
   bool enableEnergy, enablePressure, enableDens, enableVolume, enableMol;
   bool enableSurfTension, enableStat;
   bool WriteConsoleHeaders;
@@ -80,7 +80,7 @@ private:
   void PrintEnergyTitle();
   void PrintStatisticTitle();
   void PrintMoveTitle();
-  void printElement(const double t, const int width, uint precision = 4) const;
+  void printElement(const double t, const int width, uint precision = 8) const;
   void printElement(const uint t, const int width) const;
   void printElement(const std::string t, const int width) const;
 


### PR DESCRIPTION
Instead of tracking a value in the OutputVariables, there was a manually calculated value of entropy in the ENER_ line of console out.  This was removed, since the tracked variable for entropy is already printed in the STAT_ line.  This line also matches the Blk files.

Also, precision of console outputs is now 8 decimal points to match Block outputs.

BPTI/TIP3 example
[log.txt](https://github.com/GOMC-WSU/GOMC/files/9183397/log.txt)
[Blk_0.txt](https://github.com/GOMC-WSU/GOMC/files/9183398/Blk_0.txt)
[Blk_1.txt](https://github.com/GOMC-WSU/GOMC/files/9183399/Blk_1.txt)

