### PR TITLE
Fix #463: Simulations with Mie potential could produce NaNs and terminate

### DIFF
--- a/src/FFParticle.cpp
+++ b/src/FFParticle.cpp
@@ -166,7 +166,7 @@ void FFParticle::Blend(ff_setup::Particle const& mie)
       }
 
       //Warning: Causes division by zero if n (or n_1_4) = 0 or 6.
-      //Handled through error checking in FFSetup::Read().
+      //Handled through error checking in FFSetup::Read() to require n (and n_1_4) > 6.
       double cn = n[idx] / (n[idx] - 6.0) * pow(n[idx] / 6.0, (6.0 / (n[idx] - 6.0)));
       double cn_1_4 = n_1_4[idx] / (n_1_4[idx] - 6.0) *
                       pow(n_1_4[idx] / 6.0, (6.0 / (n_1_4[idx] - 6.0)));

--- a/src/FFParticle.cpp
+++ b/src/FFParticle.cpp
@@ -164,6 +164,9 @@ void FFParticle::Blend(ff_setup::Particle const& mie)
         n[idx] = num::MeanA(mie.n, mie.n, i, j);
         n_1_4[idx] = num::MeanA(mie.n_1_4, mie.n_1_4, i, j);
       }
+
+      //Warning: Causes division by zero if n (or n_1_4) = 0 or 6.
+      //Handled through error checking in FFSetup::Read().
       double cn = n[idx] / (n[idx] - 6.0) * pow(n[idx] / 6.0, (6.0 / (n[idx] - 6.0)));
       double cn_1_4 = n_1_4[idx] / (n_1_4[idx] - 6.0) *
                       pow(n_1_4[idx] / 6.0, (6.0 / (n_1_4[idx] - 6.0)));

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -213,6 +213,29 @@ void Particle::Read(Reader & param, std::string const& firstVar)
   if (isCHARMM() || values.fail()) {
     expN_1_4 = expN;
   }
+
+  //Reset values and perform error checking for consistency.
+  //If epsilon = 0 then the sigma and exponent values don't impact the computation.
+  //But need the exponents to be large enough that the arithmetic or geometric mean of any pair > 6.0.
+  //See FFParticle::Blend() for underlying math.
+  double smallVal = 1e-20;
+  if (abs(e) < smallVal) {
+    e = 0.0;
+    expN = 12.0; //Set to default (LJ) exponent.
+  } 
+  if (abs(e_1_4) < smallVal) {
+    e_1_4 = 0.0;
+    expN_1_4 = 12.0; //Set to default (LJ) exponent.
+  } 
+  if ((expN - 6.0) < smallVal) {
+    std::cout << "ERROR: Mie exponent must be > 6!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  if ((expN_1_4 - 6.0) < smallVal) {
+    std::cout << "ERROR: Mie exponent for 1-4 interactions must be > 6!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  
   Add(e, s, expN, e_1_4, s_1_4, expN_1_4);
 }
 

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -216,8 +216,8 @@ void Particle::Read(Reader & param, std::string const& firstVar)
 
   //Reset values and perform error checking for consistency.
   //If epsilon = 0 then the sigma and exponent values don't impact the computation.
-  //But need the exponents to be large enough that the arithmetic or geometric mean of any pair > 6.0.
-  //See FFParticle::Blend() for underlying math.
+  //But need the exponents to be large enough that the arithmetic or geometric mean
+  //of any pair > 6.0. See FFParticle::Blend() for underlying math.
   double smallVal = 1e-20;
   if (abs(e) < smallVal) {
     e = 0.0;


### PR DESCRIPTION
Low values for the exponent (<= 6.0) could result in division by zero. This patch resolves issue #463 by doing better error handling on the input Mie potentials. Error messages are generated if the exponents are too small.

If epsilon = 0 then the exponent is adjusted to avoid division by zero and the simulation continues, as these exponents aren't used in this case.