### PR TITLE
shorten and eliminate most examples for testing integration scripts

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,7 +6,7 @@
 ### If you are on development when you run the script,
 ### the this will be the main branch.
 ###
-### If you are non a feature branch, 
+### If you are a new feature branch, 
 ### this will be the development branch
 ###
 ### The current branch is compiled and the binaries put into new_binaries 

--- a/test/README.md
+++ b/test/README.md
@@ -1,24 +1,24 @@
-### Instructions for running integration tests
+# Instructions for running integration tests
 
-# Clones GOMC_Examples repo and creates 4 copies 
-# CPU_Ref, GPU_Ref, CPU_New, GPU_Ref
-# Then is will checkout the mosy likely branch to merge into
-# If you are on development when you run the script,
-# the this will be the main branch.
-#
-# If you are non a feature branch, 
-# this will be the development branch
-#
-# The current branch is compiled and the binaries put into new_binaries 
-# The ref branch is compiled and the binaries put into ref_binaries 
+### Clones GOMC_Examples repo and creates 4 copies 
+### CPU_Ref, GPU_Ref, CPU_New, GPU_Ref
+### Then is will checkout the mosy likely branch to merge into
+### If you are on development when you run the script,
+### the this will be the main branch.
+###
+### If you are non a feature branch, 
+### this will be the development branch
+###
+### The current branch is compiled and the binaries put into new_binaries 
+### The ref branch is compiled and the binaries put into ref_binaries 
 
 $ bash Setup_Examples.sh 
 
-# Then the actual examples are run in serial
+### Then the actual examples are run in serial
 
 $ python Run_Examples.py
 
-# The results are in integration/IntegrationTest.log
-# To check for pass/fail in color coded output
+### The results are in integration/IntegrationTest.log
+### To check for pass/fail in color coded output
 
 $ cat integration/IntegrationTest.log

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,24 @@
+### Instructions for running integration tests
+
+# Clones GOMC_Examples repo and creates 4 copies 
+# CPU_Ref, GPU_Ref, CPU_New, GPU_Ref
+# Then is will checkout the mosy likely branch to merge into
+# If you are on development when you run the script,
+# the this will be the main branch.
+#
+# If you are non a feature branch, 
+# this will be the development branch
+#
+# The current branch is compiled and the binaries put into new_binaries 
+# The ref branch is compiled and the binaries put into ref_binaries 
+
+$ bash Setup_Examples.sh 
+
+# Then the actual examples are run in serial
+
+$ python Run_Examples.py
+
+# The results are in integration/IntegrationTest.log
+# To check for pass/fail in color coded output
+
+$ cat integration/IntegrationTest.log

--- a/test/README.md
+++ b/test/README.md
@@ -2,11 +2,12 @@
 
 ### Clones GOMC_Examples repo and creates 4 copies 
 ### CPU_Ref, GPU_Ref, CPU_New, GPU_Ref
-### Then is will checkout the most likely branch to merge into
+### This script will compile the current branch and then
+### will checkout the most likely branch you want to merge into.
 ### If you are on development when you run the script,
 ### the this will be the main branch.
 ###
-### If you are a new feature branch, 
+### If you are on a new feature branch, 
 ### this will be the development branch
 ###
 ### The current branch is compiled and the binaries put into new_binaries 

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 ### Clones GOMC_Examples repo and creates 4 copies 
 ### CPU_Ref, GPU_Ref, CPU_New, GPU_Ref
-### Then is will checkout the mosy likely branch to merge into
+### Then is will checkout the most likely branch to merge into
 ### If you are on development when you run the script,
 ### the this will be the main branch.
 ###

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@
 ### This script will compile the current branch and then
 ### will checkout the most likely branch you want to merge into.
 ### If you are on development when you run the script,
-### the this will be the main branch.
+### this will be the main branch.
 ###
 ### If you are on a new feature branch, 
 ### this will be the development branch

--- a/test/Setup_Examples.sh
+++ b/test/Setup_Examples.sh
@@ -9,6 +9,7 @@ rm -frd GOMC_Examples/NVT
 rm -frd GOMC_Examples/GCMC
 rm -frd GOMC_Examples/NPT_GEMC
 rm -frd GOMC_Examples/NVT_GEMC
+rm -frd GOMC_Examples/MoSDef-GOMC
 mkdir integration
 
 mkdir integration/new_cpu

--- a/test/Setup_Examples.sh
+++ b/test/Setup_Examples.sh
@@ -10,6 +10,12 @@ rm -frd GOMC_Examples/GCMC
 rm -frd GOMC_Examples/NPT_GEMC
 rm -frd GOMC_Examples/NVT_GEMC
 rm -frd GOMC_Examples/MoSDef-GOMC
+
+# Modify this file 
+#/home/greg/Documents/GOMC/test/GOMC_Examples/NPT/DME_constArea_340_00_K/in.conf
+# TO DO
+# awk ....
+
 mkdir integration
 
 mkdir integration/new_cpu

--- a/test/Setup_Examples.sh
+++ b/test/Setup_Examples.sh
@@ -28,7 +28,7 @@ cd ..
 startingBranch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 echo "Building $startingBranch binaries"
 
-./metamake.sh -g
+./metamake.sh -g NPT
 mkdir -p test/new_binaries
 cp -frdp ./bin/* test/new_binaries
 
@@ -44,7 +44,7 @@ fi
 rm -frd bin
 refBranch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 echo "Building $refBranch binaries"
-./metamake.sh -g
+./metamake.sh -g NPT
 mkdir -p test/ref_binaries
 cp -frd ./bin/* test/ref_binaries
 cd test

--- a/test/Setup_Examples.sh
+++ b/test/Setup_Examples.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 git clone https://github.com/GOMC-WSU/GOMC_Examples.git
+cd GOMC_Examples
+## TO DO- make this a command line option once new tests are done.
+git checkout quick_testing
+cd ..
+rm -frd GOMC_Examples/NPT/water_580_00_K
+rm -frd GOMC_Examples/NVT
+rm -frd GOMC_Examples/GCMC
+rm -frd GOMC_Examples/NPT_GEMC
+rm -frd GOMC_Examples/NVT_GEMC
 mkdir integration
 
 mkdir integration/new_cpu

--- a/test/Setup_Examples.sh
+++ b/test/Setup_Examples.sh
@@ -2,7 +2,7 @@
 git clone https://github.com/GOMC-WSU/GOMC_Examples.git
 cd GOMC_Examples
 ## TO DO- make this a command line option once new tests are done.
-git checkout quick_testing
+#git checkout quick_testing
 cd ..
 rm -frd GOMC_Examples/NPT/water_580_00_K
 rm -frd GOMC_Examples/NVT


### PR DESCRIPTION
Modified testing setup script to clone quick_testing branch of GOMC_Examples and remove all but NPT/DME example to get python data parsing and analysis working.