### PR TITLE
Fix logic in ComparePotentials function

### DIFF
--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -436,7 +436,6 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
     std::cout << "difference: "
               << totalEnergy.intraBond - other.totalEnergy.intraBond
               << std::endl;
-    returnVal = false;
     if (totalEnergy.bond != other.totalEnergy.bond) {
       std::cout << "my bond: " << totalEnergy.bond
                 << "  other bond: " << other.totalEnergy.bond << std::endl;
@@ -457,6 +456,7 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
                 << totalEnergy.dihedral - other.totalEnergy.dihedral
                 << std::endl;
     }
+    returnVal = false;
   }
   if (totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
     std::cout << "my intraNonbond: " << totalEnergy.intraNonbond
@@ -483,7 +483,6 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
     std::cout << "difference: "
               << totalEnergy.totalElect - other.totalEnergy.totalElect
               << std::endl;
-    returnVal = false;
     if (totalEnergy.real != other.totalEnergy.real) {
       std::cout << "my real: " << totalEnergy.real
                 << "  other real: " << other.totalEnergy.real << std::endl;
@@ -510,6 +509,7 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
                 << totalEnergy.correction - other.totalEnergy.correction
                 << std::endl;
     }
+    returnVal = false;
   }
   if (totalEnergy.total != other.totalEnergy.total) {
     std::cout << "my total: " << totalEnergy.total

--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -436,19 +436,18 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
     std::cout << "difference: "
               << totalEnergy.intraBond - other.totalEnergy.intraBond
               << std::endl;
+    returnVal = false;
     if (totalEnergy.bond != other.totalEnergy.bond) {
       std::cout << "my bond: " << totalEnergy.bond
                 << "  other bond: " << other.totalEnergy.bond << std::endl;
       std::cout << "difference: " << totalEnergy.bond - other.totalEnergy.bond
                 << std::endl;
-      returnVal = false;
     }
     if (totalEnergy.angle != other.totalEnergy.angle) {
       std::cout << "my angle: " << totalEnergy.angle
                 << "  other angle: " << other.totalEnergy.angle << std::endl;
       std::cout << "difference: " << totalEnergy.angle - other.totalEnergy.angle
                 << std::endl;
-      returnVal = false;
     }
     if (totalEnergy.dihedral != other.totalEnergy.dihedral) {
       std::cout << "my dihedral: " << totalEnergy.dihedral
@@ -457,46 +456,51 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
       std::cout << "difference: "
                 << totalEnergy.dihedral - other.totalEnergy.dihedral
                 << std::endl;
-      returnVal = false;
     }
-    if (totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
-      std::cout << "my intraNonbond: " << totalEnergy.intraNonbond
-                << "  other intraNonbond: " << other.totalEnergy.intraNonbond
-                << std::endl;
-      std::cout << "difference: "
-                << totalEnergy.intraNonbond - other.totalEnergy.intraNonbond
-                << std::endl;
-      returnVal = false;
-    }
-    if (totalEnergy.tailCorrection != other.totalEnergy.tailCorrection) {
-      std::cout << "my LRC: " << totalEnergy.tailCorrection
-                << "  other LRC: " << other.totalEnergy.tailCorrection
-                << std::endl;
-      std::cout << "difference: "
-                << totalEnergy.tailCorrection - other.totalEnergy.tailCorrection
-                << std::endl;
-      returnVal = false;
-    }
+  }
+  if (totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
+    std::cout << "my intraNonbond: " << totalEnergy.intraNonbond
+              << "  other intraNonbond: " << other.totalEnergy.intraNonbond
+              << std::endl;
+    std::cout << "difference: "
+              << totalEnergy.intraNonbond - other.totalEnergy.intraNonbond
+              << std::endl;
+    returnVal = false;
+  }
+  if (totalEnergy.tailCorrection != other.totalEnergy.tailCorrection) {
+    std::cout << "my LRC: " << totalEnergy.tailCorrection
+              << "  other LRC: " << other.totalEnergy.tailCorrection
+              << std::endl;
+    std::cout << "difference: "
+              << totalEnergy.tailCorrection - other.totalEnergy.tailCorrection
+              << std::endl;
+    returnVal = false;
+  }
+  if (totalEnergy.totalElect != other.totalEnergy.totalElect) {
+    std::cout << "my totalElect: " << totalEnergy.totalElect
+              << "  other totalElect: " << other.totalEnergy.totalElect
+              << std::endl;
+    std::cout << "difference: "
+              << totalEnergy.totalElect - other.totalEnergy.totalElect
+              << std::endl;
+    returnVal = false;
     if (totalEnergy.real != other.totalEnergy.real) {
       std::cout << "my real: " << totalEnergy.real
                 << "  other real: " << other.totalEnergy.real << std::endl;
       std::cout << "difference: " << totalEnergy.real - other.totalEnergy.real
                 << std::endl;
-      returnVal = false;
     }
     if (totalEnergy.recip != other.totalEnergy.recip) {
       std::cout << "my recip: " << totalEnergy.recip
                 << "  other recip: " << other.totalEnergy.recip << std::endl;
       std::cout << "difference: " << totalEnergy.recip - other.totalEnergy.recip
                 << std::endl;
-      returnVal = false;
     }
     if (totalEnergy.self != other.totalEnergy.self) {
       std::cout << "my self: " << totalEnergy.self
                 << "  other self: " << other.totalEnergy.self << std::endl;
       std::cout << "difference: " << totalEnergy.self - other.totalEnergy.self
                 << std::endl;
-      returnVal = false;
     }
     if (totalEnergy.correction != other.totalEnergy.correction) {
       std::cout << "my correction: " << totalEnergy.correction
@@ -505,26 +509,16 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
       std::cout << "difference: "
                 << totalEnergy.correction - other.totalEnergy.correction
                 << std::endl;
-      returnVal = false;
     }
-    if (totalEnergy.totalElect != other.totalEnergy.totalElect) {
-      std::cout << "my totalElect: " << totalEnergy.totalElect
-                << "  other totalElect: " << other.totalEnergy.totalElect
-                << std::endl;
-      std::cout << "difference: "
-                << totalEnergy.totalElect - other.totalEnergy.totalElect
-                << std::endl;
-      returnVal = false;
-    }
-    if (totalEnergy.total != other.totalEnergy.total) {
-      std::cout << "my total: " << totalEnergy.total
-                << "  other total: " << other.totalEnergy.total << std::endl;
-      std::cout << "difference: " << totalEnergy.total - other.totalEnergy.total
-                << std::endl;
-      returnVal = false;
-    }
-    return returnVal;
   }
+  if (totalEnergy.total != other.totalEnergy.total) {
+    std::cout << "my total: " << totalEnergy.total
+              << "  other total: " << other.totalEnergy.total << std::endl;
+    std::cout << "difference: " << totalEnergy.total - other.totalEnergy.total
+              << std::endl;
+    returnVal = false;
+  }
+  return returnVal;
 }
 
 #ifndef NDEBUG


### PR DESCRIPTION
The ComparePotentials function had incorrect logic for checking the energies. And it was not returning a value when the potentials matched. I made three changes to the code. This should be checked carefully to ensure the logic is now correct. The changes are.

1. Only bond, angle, and dihedral are checked within the if case where the intraBond energies do not match.
2. The recip, real, self, and correction energies are checked only if the totalElect energies do not match.
3. The return value is set to false when the totalElect or intraBond energies don't match  and not set again when any components don't match.
4. The code returns the return value, true or false, in all cases.

Note that I don't think this caused any incorrect output, because it doesn't look like this function is actually used in the code. But it should be fixed in any case, as it may be used in the future.