### PR TITLE
Revert the sloppy intraBonded PR

### DIFF
--- a/lib/Endian.h
+++ b/lib/Endian.h
@@ -37,7 +37,6 @@
  */
 
 #include <stdlib.h>
-#include <stdint.h>
 
 #define bswap_64(x)                                                            \
   ((((x)&0xff00000000000000ull) >> 56) | (((x)&0x00ff000000000000ull) >> 40) | \

--- a/src/CalculateEnergy.cpp
+++ b/src/CalculateEnergy.cpp
@@ -102,7 +102,7 @@ SystemPotential CalculateEnergy::SystemTotal() {
     }
 
 #ifdef _OPENMP
-    #pragma omp parallel for default(none) private(bondEnergy) shared(b, molID) \
+#pragma omp parallel for default(none) private(bondEnergy) shared(b, molID) \
     reduction(+:bondEn, nonbondEn, correction)
 #endif
     for (int i = 0; i < (int)molID.size(); i++) {
@@ -110,7 +110,7 @@ SystemPotential CalculateEnergy::SystemTotal() {
       MoleculeIntra(molID[i], b, bondEnergy);
       bondEn += bondEnergy[0];
       nonbondEn += bondEnergy[1];
-      //calculate correction term of electrostatic interaction
+      // calculate correction term of electrostatic interaction
       correction += calcEwald->MolCorrection(molID[i], b);
     }
 

--- a/src/CalculateEnergy.cpp
+++ b/src/CalculateEnergy.cpp
@@ -90,9 +90,8 @@ SystemPotential CalculateEnergy::SystemTotal() {
   // system intra
   for (uint b = 0; b < BOX_TOTAL; ++b) {
     GOMC_EVENT_START(1, GomcProfileEvent::EN_BOX_INTRA);
-    double bondEnergy[4] = {0};
-    double bondEn = 0.0, anglEn = 0.0, diheEn = 0.0, nonbondEn = 0.0,
-           correction = 0.0;
+    double bondEnergy[2] = {0};
+    double bondEn = 0.0, nonbondEn = 0.0, correction = 0.0;
     MoleculeLookup::box_iterator thisMol = molLookup.BoxBegin(b);
     MoleculeLookup::box_iterator end = molLookup.BoxEnd(b);
     std::vector<uint> molID;
@@ -103,24 +102,19 @@ SystemPotential CalculateEnergy::SystemTotal() {
     }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) private(bondEnergy) shared(b, molID) \
-    reduction(+:bondEn, anglEn, diheEn, nonbondEn, correction)
+    #pragma omp parallel for default(none) private(bondEnergy) shared(b, molID) \
+    reduction(+:bondEn, nonbondEn, correction)
 #endif
     for (int i = 0; i < (int)molID.size(); i++) {
       // calculate nonbonded energy
       MoleculeIntra(molID[i], b, bondEnergy);
       bondEn += bondEnergy[0];
-      anglEn += bondEnergy[1];
-      diheEn += bondEnergy[2];
-      nonbondEn += bondEnergy[3];
-      // calculate correction term of electrostatic interaction
+      nonbondEn += bondEnergy[1];
+      //calculate correction term of electrostatic interaction
       correction += calcEwald->MolCorrection(molID[i], b);
     }
 
-    pot.boxEnergy[b].intraBond = bondEn + anglEn + diheEn;
-    pot.boxEnergy[b].bond = bondEn;
-    pot.boxEnergy[b].angle = anglEn;
-    pot.boxEnergy[b].dihedral = diheEn;
+    pot.boxEnergy[b].intraBond = bondEn;
     pot.boxEnergy[b].intraNonbond = nonbondEn;
     // calculate self term of electrostatic interaction
     pot.boxEnergy[b].self = calcEwald->BoxSelf(b);
@@ -869,7 +863,7 @@ Intermolecular CalculateEnergy::MoleculeTailVirChange(const uint box,
 void CalculateEnergy::MoleculeIntra(const uint molIndex, const uint box,
                                     double *bondEn) const {
   GOMC_EVENT_START(1, GomcProfileEvent::EN_MOL_INTRA);
-  bondEn[0] = 0.0, bondEn[1] = 0.0, bondEn[2] = 0.0, bondEn[3] = 0.0;
+  bondEn[0] = 0.0, bondEn[1] = 0.0;
 
   MoleculeKind &molKind = mols.kinds[mols.kIndex[molIndex]];
   // *2 because we'll be storing inverse bond vectors
@@ -877,18 +871,18 @@ void CalculateEnergy::MoleculeIntra(const uint molIndex, const uint box,
 
   BondVectors(bondVec, molKind, molIndex, box);
   MolBond(bondEn[0], molKind, bondVec, molIndex, box);
-  MolAngle(bondEn[1], molKind, bondVec, box);
-  MolDihedral(bondEn[2], molKind, bondVec, box);
-  MolNonbond(bondEn[3], molKind, molIndex, box);
-  MolNonbond_1_4(bondEn[3], molKind, molIndex, box);
-  MolNonbond_1_3(bondEn[3], molKind, molIndex, box);
+  MolAngle(bondEn[0], molKind, bondVec, box);
+  MolDihedral(bondEn[0], molKind, bondVec, box);
+  MolNonbond(bondEn[1], molKind, molIndex, box);
+  MolNonbond_1_4(bondEn[1], molKind, molIndex, box);
+  MolNonbond_1_3(bondEn[1], molKind, molIndex, box);
   GOMC_EVENT_STOP(1, GomcProfileEvent::EN_MOL_INTRA);
 }
 
 // used in molecule exchange for calculating bonded and intraNonbonded energy
 Energy CalculateEnergy::MoleculeIntra(cbmc::TrialMol const &mol) const {
   GOMC_EVENT_START(1, GomcProfileEvent::EN_MOL_INTRA);
-  double bondEn = 0.0, anglEn = 0.0, diheEn = 0.0, intraNonbondEn = 0.0;
+  double bondEn = 0.0, intraNonbondEn = 0.0;
   // *2 because we'll be storing inverse bond vectors
   const MoleculeKind &molKind = mol.GetKind();
   uint count = molKind.bondList.count;
@@ -897,35 +891,13 @@ Energy CalculateEnergy::MoleculeIntra(cbmc::TrialMol const &mol) const {
 
   BondVectors(bondVec, mol, bondExist, molKind);
   MolBond(bondEn, mol, bondVec, bondExist, molKind);
-  MolAngle(anglEn, mol, bondVec, bondExist, molKind);
-  MolDihedral(diheEn, mol, bondVec, bondExist, molKind);
+  MolAngle(bondEn, mol, bondVec, bondExist, molKind);
+  MolDihedral(bondEn, mol, bondVec, bondExist, molKind);
   MolNonbond(intraNonbondEn, mol, molKind);
   MolNonbond_1_4(intraNonbondEn, mol, molKind);
   MolNonbond_1_3(intraNonbondEn, mol, molKind);
   GOMC_EVENT_STOP(1, GomcProfileEvent::EN_MOL_INTRA);
-  return Energy(bondEn, anglEn, diheEn, bondEn + anglEn + diheEn,
-                intraNonbondEn, 0.0, 0.0, 0.0, 0.0, 0.0);
-}
-
-// used in molecule exchange for calculating bonded and intraNonbonded energy
-Energy CalculateEnergy::UpdateBondAngleDihe(cbmc::TrialMol const &mol) const {
-  GOMC_EVENT_START(1, GomcProfileEvent::EN_MOL_INTRA);
-  double bondEn = 0.0, anglEn = 0.0, diheEn = 0.0, intraNonbondEn = 0.0;
-  // *2 because we'll be storing inverse bond vectors
-  const MoleculeKind &molKind = mol.GetKind();
-  uint count = molKind.bondList.count;
-  XYZArray bondVec(count * 2);
-  std::vector<bool> bondExist(count * 2, false);
-
-  BondVectors(bondVec, mol, bondExist, molKind);
-  MolBond(bondEn, mol, bondVec, bondExist, molKind);
-  MolAngle(anglEn, mol, bondVec, bondExist, molKind);
-  MolDihedral(diheEn, mol, bondVec, bondExist, molKind);
-  MolNonbond(intraNonbondEn, mol, molKind);
-  MolNonbond_1_4(intraNonbondEn, mol, molKind);
-  MolNonbond_1_3(intraNonbondEn, mol, molKind);
-  GOMC_EVENT_STOP(1, GomcProfileEvent::EN_MOL_INTRA);
-  return Energy(bondEn, anglEn, diheEn, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  return Energy(bondEn, intraNonbondEn, 0.0, 0.0, 0.0, 0.0, 0.0);
 }
 
 void CalculateEnergy::BondVectors(XYZArray &vecs, MoleculeKind const &molKind,

--- a/src/CalculateEnergy.h
+++ b/src/CalculateEnergy.h
@@ -143,7 +143,6 @@ public:
   // used in molecule exchange for calculating bonded and intraNonbonded energy
   Energy MoleculeIntra(cbmc::TrialMol const &mol) const;
 
-
   //! Calculates Nonbonded 1_3 intramolecule energy of a full molecule
   // for Martini forcefield
   double IntraEnergy_1_3(const double distSq, const uint atom1,

--- a/src/CalculateEnergy.h
+++ b/src/CalculateEnergy.h
@@ -143,8 +143,6 @@ public:
   // used in molecule exchange for calculating bonded and intraNonbonded energy
   Energy MoleculeIntra(cbmc::TrialMol const &mol) const;
 
-  // used in molecule exchange for calculating bonded and intraNonbonded energy
-  Energy UpdateBondAngleDihe(cbmc::TrialMol const &mol) const;
 
   //! Calculates Nonbonded 1_3 intramolecule energy of a full molecule
   // for Martini forcefield

--- a/src/Clock.h
+++ b/src/Clock.h
@@ -22,8 +22,8 @@ along with this program, also can be found at
 #endif
 
 struct Clock {
-  Clock() : lastTime(0.0), stepsPerOut(0), prevStep(0), firstStep(0),
-      lastStep(0) {}
+  Clock()
+      : lastTime(0.0), stepsPerOut(0), prevStep(0), firstStep(0), lastStep(0) {}
   void Init(const ulong steps, const ulong totSt, const ulong startStep) {
     stepsPerOut = steps;
     prevStep = startStep;
@@ -119,7 +119,8 @@ inline void Clock::CompletionTime(uint &day, uint &hr, uint &min) {
 #if defined(__linux__) || defined(__APPLE__)
   speed = (double)(prevStep - firstStep) / (lastTime - strt);
 #elif (_WIN32) || (__CYGWIN__)
-  speed = (double)(prevStep - firstStep) / ((double)(lastTime - strt) / CLOCKS_PER_SEC);
+  speed = (double)(prevStep - firstStep) /
+          ((double)(lastTime - strt) / CLOCKS_PER_SEC);
 #endif
   ulong rem = lastStep - prevStep;
   ulong sec = rem / speed;

--- a/src/ConsoleOutput.cpp
+++ b/src/ConsoleOutput.cpp
@@ -304,9 +304,6 @@ void ConsoleOutput::PrintEnergy(const uint box, Energy const &en,
 
   printElement(en.total, elementWidth);
   printElement(en.intraBond, elementWidth);
-  printElement(en.bond, elementWidth);
-  printElement(en.angle, elementWidth);
-  printElement(en.dihedral, elementWidth);
   printElement(en.intraNonbond, elementWidth);
   printElement(en.inter, elementWidth);
   printElement(en.tailCorrection, elementWidth);
@@ -325,9 +322,6 @@ void ConsoleOutput::PrintEnergyTitle() {
 
   printElement("TOTAL", elementWidth);
   printElement("INTRA(B)", elementWidth);
-  printElement("BOND(B)", elementWidth);
-  printElement("ANGLE(B)", elementWidth);
-  printElement("DIHEDRAL(B)", elementWidth);
   printElement("INTRA(NB)", elementWidth);
   printElement("INTER(LJ)", elementWidth);
   printElement("LRC", elementWidth);

--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -76,29 +76,20 @@ struct Intermolecular {
 
 class Energy {
 public:
-  Energy()
-      : bond(0.0), angle(0.0), dihedral(0.0), intraBond(0.0), intraNonbond(0.0),
-        inter(0.0), tailCorrection(0.0), total(0.0), real(0.0), recip(0.0),
-        self(0.0), correction(0.0), totalElect(0.0) {}
-  // For CBMC
-  Energy(double intraBond, double nonbond, double inter, double real,
-         double recip, double self, double correc)
-      : bond(0.0), angle(0.0), dihedral(0.0), intraBond(intraBond),
-        intraNonbond(nonbond), inter(inter), tailCorrection(0.0), total(0.0),
-        real(real), recip(recip), self(self), correction(correc),
-        totalElect(0.0) {}
-  Energy(double bond, double angle, double dihedral, double intraBond,
-         double nonbond, double inter, double real, double recip, double self,
-         double correc)
-      : bond(bond), angle(angle), dihedral(dihedral), intraBond(bond),
-        intraNonbond(nonbond), inter(inter), tailCorrection(0.0), total(0.0),
-        real(real), recip(recip), self(self), correction(correc),
-        totalElect(0.0) {}
+  Energy() : intraBond(0.0), intraNonbond(0.0), inter(0.0),
+    tailCorrection(0.0), total(0.0), real(0.0), recip(0.0), self(0.0),
+    correction(0.0), totalElect(0.0) {}
+  Energy(double bond, double nonbond, double inter, double real,
+         double recip, double self, double correc) :
+    intraBond(bond), intraNonbond(nonbond), inter(inter),
+    tailCorrection(0.0), total(0.0), real(real), recip(recip), self(self),
+    correction(correc), totalElect(0.0) {}
 
-  // VALUE SETTERS
-  double Total() {
-    total = intraBond + intraNonbond + inter + tailCorrection + real + recip +
-            self + correction;
+  //VALUE SETTERS
+  double Total()
+  {
+    total = intraBond + intraNonbond + inter + tailCorrection + real + recip + self +
+            correction;
     return total;
   }
 
@@ -107,10 +98,8 @@ public:
     return totalElect;
   }
 
-  void Zero() {
-    bond = 0.0;
-    angle = 0.0;
-    dihedral = 0.0;
+  void Zero()
+  {
     intraBond = 0.0;
     intraNonbond = 0.0;
     inter = 0.0;
@@ -136,17 +125,14 @@ public:
   Energy &operator+=(Energy const &rhs);
   Energy &operator*=(double const &rhs);
 
-  // private:
-  // MEMBERS
-  double bond, angle, dihedral, intraBond, intraNonbond, inter, tailCorrection,
-      total, real, recip, self, correction, totalElect;
+//private:
+  //MEMBERS
+  double intraBond, intraNonbond, inter, tailCorrection, total, real, recip, self,
+         correction, totalElect;
 };
 
 inline Energy &Energy::operator-=(Energy const &rhs) {
   inter -= rhs.inter;
-  bond -= rhs.bond;
-  angle -= rhs.angle;
-  dihedral -= rhs.dihedral;
   intraBond -= rhs.intraBond;
   intraNonbond -= rhs.intraNonbond;
   tailCorrection -= rhs.tailCorrection;
@@ -162,9 +148,6 @@ inline Energy &Energy::operator-=(Energy const &rhs) {
 
 inline Energy &Energy::operator+=(Energy const &rhs) {
   inter += rhs.inter;
-  bond += rhs.bond;
-  angle += rhs.angle;
-  dihedral += rhs.dihedral;
   intraBond += rhs.intraBond;
   intraNonbond += rhs.intraNonbond;
   tailCorrection += rhs.tailCorrection;
@@ -180,9 +163,6 @@ inline Energy &Energy::operator+=(Energy const &rhs) {
 
 inline Energy &Energy::operator*=(double const &rhs) {
   inter *= rhs;
-  bond *= rhs;
-  angle *= rhs;
-  dihedral *= rhs;
   intraBond *= rhs;
   intraNonbond *= rhs;
   tailCorrection *= rhs;
@@ -429,33 +409,29 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
     returnVal = false;
   }
 
-  if (totalEnergy.intraBond != other.totalEnergy.intraBond) {
-    std::cout << "my intraBond: " << totalEnergy.intraBond
-              << "  other intraBond: " << other.totalEnergy.intraBond
-              << std::endl;
-    std::cout << "difference: "
-              << totalEnergy.intraBond - other.totalEnergy.intraBond
-              << std::endl;
-    if (totalEnergy.bond != other.totalEnergy.bond) {
-      std::cout << "my bond: " << totalEnergy.bond
-                << "  other bond: " << other.totalEnergy.bond << std::endl;
-      std::cout << "difference: " << totalEnergy.bond - other.totalEnergy.bond
-                << std::endl;
-    }
-    if (totalEnergy.angle != other.totalEnergy.angle) {
-      std::cout << "my angle: " << totalEnergy.angle
-                << "  other angle: " << other.totalEnergy.angle << std::endl;
-      std::cout << "difference: " << totalEnergy.angle - other.totalEnergy.angle
-                << std::endl;
-    }
-    if (totalEnergy.dihedral != other.totalEnergy.dihedral) {
-      std::cout << "my dihedral: " << totalEnergy.dihedral
-                << "  other dihedral: " << other.totalEnergy.dihedral
-                << std::endl;
-      std::cout << "difference: "
-                << totalEnergy.dihedral - other.totalEnergy.dihedral
-                << std::endl;
-    }
+  if(totalEnergy.intraBond != other.totalEnergy.intraBond) {
+    std::cout << "my intraBond: " << totalEnergy.intraBond << "  other intraBond: " << other.totalEnergy.intraBond << std::endl;
+    std::cout << "difference: " << totalEnergy.intraBond - other.totalEnergy.intraBond << std::endl;
+    returnVal = false;
+  }
+  if(totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
+    std::cout << "my intraNonbond: " << totalEnergy.intraNonbond << "  other intraNonbond: " << other.totalEnergy.intraNonbond << std::endl;
+    std::cout << "difference: " << totalEnergy.intraNonbond - other.totalEnergy.intraNonbond << std::endl;
+    returnVal = false;
+  }
+  if(totalEnergy.tailCorrection != other.totalEnergy.tailCorrection) {
+    std::cout << "my LRC: " << totalEnergy.tailCorrection << "  other LRC: " << other.totalEnergy.tailCorrection << std::endl;
+    std::cout << "difference: " << totalEnergy.tailCorrection - other.totalEnergy.tailCorrection << std::endl;
+    returnVal = false;
+  }
+  if(totalEnergy.real != other.totalEnergy.real) {
+    std::cout << "my real: " << totalEnergy.real << "  other real: " << other.totalEnergy.real << std::endl;
+    std::cout << "difference: " << totalEnergy.real - other.totalEnergy.real << std::endl;
+    returnVal = false;
+  }
+  if(totalEnergy.recip != other.totalEnergy.recip) {
+    std::cout << "my recip: " << totalEnergy.recip << "  other recip: " << other.totalEnergy.recip << std::endl;
+    std::cout << "difference: " << totalEnergy.recip - other.totalEnergy.recip << std::endl;
     returnVal = false;
   }
   if (totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
@@ -522,33 +498,29 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
 }
 
 #ifndef NDEBUG
-  inline std::ostream &operator<<(std::ostream &out, Energy &en) {
-    // Save existing settings for the ostream
-    std::streamsize ss = out.precision();
-    std::ios_base::fmtflags ff = out.flags();
+inline std::ostream& operator<<(std::ostream& out, Energy& en)
+{
+  //Save existing settings for the ostream
+  std::streamsize ss = out.precision();
+  std::ios_base::fmtflags ff = out.flags();
 
-    en.Total();
-    en.TotalElect();
+  en.Total();
+  en.TotalElect();
 
-    out << std::setprecision(6) << std::fixed;
-    out << "\tTotal: " << en.total << "  IntraB: " << en.intraBond
-        << "  Bond: " << en.bond << "  Angle: " << en.angle
-        << "  Dihedral: " << en.dihedral << "  IntraNB: " << en.intraNonbond
-        << "  Inter: " << en.inter
-        << "  Tail Correction: " << en.tailCorrection;
+  out << std::setprecision(6) << std::fixed;
+  out << "\tTotal: " << en.total << "  IntraB: " << en.intraBond << "  IntraNB: "
+      << en.intraNonbond << "  Inter: " << en.inter << "  LRC: " << en.tailCorrection;
+  if (en.totalElect != 0.0) {
+    out << std::endl << "\tTotal Electric: " << en.totalElect << "  Real: " << en.real
+        << "  Recip: " << en.recip << "  Self: " << en.self << "  Correction: "
+        << en.correction;
 
-    if (en.totalElect != 0.0) {
-      out << std::endl
-          << "\tTotal Electric: " << en.totalElect << "  Real: " << en.real
-          << "  Recip: " << en.recip << "  Self: " << en.self
-          << "  Correction: " << en.correction;
-
-      // Restore ostream settings to prior value
-      out << std::setprecision(ss);
-      out.flags(ff);
-    }
-    return out;
+  //Restore ostream settings to prior value
+  out << std::setprecision(ss);
+  out.flags(ff);
   }
+  return out;
+}
 #endif
 
 #endif

--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -76,20 +76,20 @@ struct Intermolecular {
 
 class Energy {
 public:
-  Energy() : intraBond(0.0), intraNonbond(0.0), inter(0.0),
-    tailCorrection(0.0), total(0.0), real(0.0), recip(0.0), self(0.0),
-    correction(0.0), totalElect(0.0) {}
-  Energy(double bond, double nonbond, double inter, double real,
-         double recip, double self, double correc) :
-    intraBond(bond), intraNonbond(nonbond), inter(inter),
-    tailCorrection(0.0), total(0.0), real(real), recip(recip), self(self),
-    correction(correc), totalElect(0.0) {}
+  Energy()
+      : intraBond(0.0), intraNonbond(0.0), inter(0.0), tailCorrection(0.0),
+        total(0.0), real(0.0), recip(0.0), self(0.0), correction(0.0),
+        totalElect(0.0) {}
+  Energy(double bond, double nonbond, double inter, double real, double recip,
+         double self, double correc)
+      : intraBond(bond), intraNonbond(nonbond), inter(inter),
+        tailCorrection(0.0), total(0.0), real(real), recip(recip), self(self),
+        correction(correc), totalElect(0.0) {}
 
-  //VALUE SETTERS
-  double Total()
-  {
-    total = intraBond + intraNonbond + inter + tailCorrection + real + recip + self +
-            correction;
+  // VALUE SETTERS
+  double Total() {
+    total = intraBond + intraNonbond + inter + tailCorrection + real + recip +
+            self + correction;
     return total;
   }
 
@@ -98,8 +98,7 @@ public:
     return totalElect;
   }
 
-  void Zero()
-  {
+  void Zero() {
     intraBond = 0.0;
     intraNonbond = 0.0;
     inter = 0.0;
@@ -125,10 +124,10 @@ public:
   Energy &operator+=(Energy const &rhs);
   Energy &operator*=(double const &rhs);
 
-//private:
-  //MEMBERS
-  double intraBond, intraNonbond, inter, tailCorrection, total, real, recip, self,
-         correction, totalElect;
+  // private:
+  // MEMBERS
+  double intraBond, intraNonbond, inter, tailCorrection, total, real, recip,
+      self, correction, totalElect;
 };
 
 inline Energy &Energy::operator-=(Energy const &rhs) {
@@ -409,29 +408,45 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
     returnVal = false;
   }
 
-  if(totalEnergy.intraBond != other.totalEnergy.intraBond) {
-    std::cout << "my intraBond: " << totalEnergy.intraBond << "  other intraBond: " << other.totalEnergy.intraBond << std::endl;
-    std::cout << "difference: " << totalEnergy.intraBond - other.totalEnergy.intraBond << std::endl;
+  if (totalEnergy.intraBond != other.totalEnergy.intraBond) {
+    std::cout << "my intraBond: " << totalEnergy.intraBond
+              << "  other intraBond: " << other.totalEnergy.intraBond
+              << std::endl;
+    std::cout << "difference: "
+              << totalEnergy.intraBond - other.totalEnergy.intraBond
+              << std::endl;
     returnVal = false;
   }
-  if(totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
-    std::cout << "my intraNonbond: " << totalEnergy.intraNonbond << "  other intraNonbond: " << other.totalEnergy.intraNonbond << std::endl;
-    std::cout << "difference: " << totalEnergy.intraNonbond - other.totalEnergy.intraNonbond << std::endl;
+  if (totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
+    std::cout << "my intraNonbond: " << totalEnergy.intraNonbond
+              << "  other intraNonbond: " << other.totalEnergy.intraNonbond
+              << std::endl;
+    std::cout << "difference: "
+              << totalEnergy.intraNonbond - other.totalEnergy.intraNonbond
+              << std::endl;
     returnVal = false;
   }
-  if(totalEnergy.tailCorrection != other.totalEnergy.tailCorrection) {
-    std::cout << "my LRC: " << totalEnergy.tailCorrection << "  other LRC: " << other.totalEnergy.tailCorrection << std::endl;
-    std::cout << "difference: " << totalEnergy.tailCorrection - other.totalEnergy.tailCorrection << std::endl;
+  if (totalEnergy.tailCorrection != other.totalEnergy.tailCorrection) {
+    std::cout << "my LRC: " << totalEnergy.tailCorrection
+              << "  other LRC: " << other.totalEnergy.tailCorrection
+              << std::endl;
+    std::cout << "difference: "
+              << totalEnergy.tailCorrection - other.totalEnergy.tailCorrection
+              << std::endl;
     returnVal = false;
   }
-  if(totalEnergy.real != other.totalEnergy.real) {
-    std::cout << "my real: " << totalEnergy.real << "  other real: " << other.totalEnergy.real << std::endl;
-    std::cout << "difference: " << totalEnergy.real - other.totalEnergy.real << std::endl;
+  if (totalEnergy.real != other.totalEnergy.real) {
+    std::cout << "my real: " << totalEnergy.real
+              << "  other real: " << other.totalEnergy.real << std::endl;
+    std::cout << "difference: " << totalEnergy.real - other.totalEnergy.real
+              << std::endl;
     returnVal = false;
   }
-  if(totalEnergy.recip != other.totalEnergy.recip) {
-    std::cout << "my recip: " << totalEnergy.recip << "  other recip: " << other.totalEnergy.recip << std::endl;
-    std::cout << "difference: " << totalEnergy.recip - other.totalEnergy.recip << std::endl;
+  if (totalEnergy.recip != other.totalEnergy.recip) {
+    std::cout << "my recip: " << totalEnergy.recip
+              << "  other recip: " << other.totalEnergy.recip << std::endl;
+    std::cout << "difference: " << totalEnergy.recip - other.totalEnergy.recip
+              << std::endl;
     returnVal = false;
   }
   if (totalEnergy.intraNonbond != other.totalEnergy.intraNonbond) {
@@ -498,9 +513,8 @@ inline bool SystemPotential::ComparePotentials(SystemPotential &other) {
 }
 
 #ifndef NDEBUG
-inline std::ostream& operator<<(std::ostream& out, Energy& en)
-{
-  //Save existing settings for the ostream
+inline std::ostream &operator<<(std::ostream &out, Energy &en) {
+  // Save existing settings for the ostream
   std::streamsize ss = out.precision();
   std::ios_base::fmtflags ff = out.flags();
 
@@ -508,16 +522,18 @@ inline std::ostream& operator<<(std::ostream& out, Energy& en)
   en.TotalElect();
 
   out << std::setprecision(6) << std::fixed;
-  out << "\tTotal: " << en.total << "  IntraB: " << en.intraBond << "  IntraNB: "
-      << en.intraNonbond << "  Inter: " << en.inter << "  LRC: " << en.tailCorrection;
+  out << "\tTotal: " << en.total << "  IntraB: " << en.intraBond
+      << "  IntraNB: " << en.intraNonbond << "  Inter: " << en.inter
+      << "  LRC: " << en.tailCorrection;
   if (en.totalElect != 0.0) {
-    out << std::endl << "\tTotal Electric: " << en.totalElect << "  Real: " << en.real
-        << "  Recip: " << en.recip << "  Self: " << en.self << "  Correction: "
-        << en.correction;
+    out << std::endl
+        << "\tTotal Electric: " << en.totalElect << "  Real: " << en.real
+        << "  Recip: " << en.recip << "  Self: " << en.self
+        << "  Correction: " << en.correction;
 
-  //Restore ostream settings to prior value
-  out << std::setprecision(ss);
-  out.flags(ff);
+    // Restore ostream settings to prior value
+    out << std::setprecision(ss);
+    out.flags(ff);
   }
   return out;
 }

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -168,38 +168,47 @@ bool Simulation::RecalculateAndCheck(void) {
   SystemPotential pot = system->calcEnergy.SystemTotal();
 
   bool compare = true;
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraBond, pot.totalEnergy.intraBond, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraNonbond, pot.totalEnergy.intraNonbond, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.inter, pot.totalEnergy.inter, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.tailCorrection, pot.totalEnergy.tailCorrection, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.real, pot.totalEnergy.real, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.self, pot.totalEnergy.self, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.correction, pot.totalEnergy.correction, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.recip, pot.totalEnergy.recip, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraBond,
+                                     pot.totalEnergy.intraBond, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraNonbond,
+                                     pot.totalEnergy.intraNonbond, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.inter,
+                                     pot.totalEnergy.inter, EPSILON);
+  compare &=
+      num::approximatelyEqual(system->potential.totalEnergy.tailCorrection,
+                              pot.totalEnergy.tailCorrection, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.real,
+                                     pot.totalEnergy.real, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.self,
+                                     pot.totalEnergy.self, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.correction,
+                                     pot.totalEnergy.correction, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.recip,
+                                     pot.totalEnergy.recip, EPSILON);
 
-  if(!compare) {
+  if (!compare) {
     std::cout
         << "=================================================================\n"
-        << "Energy       INTRA B |     INTRA NB |        INTER |           TC |         REAL |         SELF |   CORRECTION |        RECIP"
+        << "Energy       INTRA B |     INTRA NB |        INTER |           TC "
+           "|         REAL |         SELF |   CORRECTION |        RECIP"
         << std::endl
-        << "System: "
-        << std::setw(12) << system->potential.totalEnergy.intraBond << " | "
-        << std::setw(12) << system->potential.totalEnergy.intraNonbond << " | "
-        << std::setw(12) << system->potential.totalEnergy.inter << " | "
-        << std::setw(12) << system->potential.totalEnergy.tailCorrection << " | "
+        << "System: " << std::setw(12)
+        << system->potential.totalEnergy.intraBond << " | " << std::setw(12)
+        << system->potential.totalEnergy.intraNonbond << " | " << std::setw(12)
+        << system->potential.totalEnergy.inter << " | " << std::setw(12)
+        << system->potential.totalEnergy.tailCorrection << " | "
         << std::setw(12) << system->potential.totalEnergy.real << " | "
         << std::setw(12) << system->potential.totalEnergy.self << " | "
         << std::setw(12) << system->potential.totalEnergy.correction << " | "
         << std::setw(12) << system->potential.totalEnergy.recip << std::endl
-        << "Recalc: "
-        << std::setw(12) << pot.totalEnergy.intraBond << " | "
+        << "Recalc: " << std::setw(12) << pot.totalEnergy.intraBond << " | "
         << std::setw(12) << pot.totalEnergy.intraNonbond << " | "
-        << std::setw(12) << pot.totalEnergy.inter << " | "
-        << std::setw(12) << pot.totalEnergy.tailCorrection << " | "
-        << std::setw(12) << pot.totalEnergy.real << " | "
-        << std::setw(12) << pot.totalEnergy.self << " | "
-        << std::setw(12) << pot.totalEnergy.correction << " | "
-        << std::setw(12) << pot.totalEnergy.recip << std::endl
+        << std::setw(12) << pot.totalEnergy.inter << " | " << std::setw(12)
+        << pot.totalEnergy.tailCorrection << " | " << std::setw(12)
+        << pot.totalEnergy.real << " | " << std::setw(12)
+        << pot.totalEnergy.self << " | " << std::setw(12)
+        << pot.totalEnergy.correction << " | " << std::setw(12)
+        << pot.totalEnergy.recip << std::endl
         << "================================================================"
         << std::endl
         << std::endl;

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -168,61 +168,38 @@ bool Simulation::RecalculateAndCheck(void) {
   SystemPotential pot = system->calcEnergy.SystemTotal();
 
   bool compare = true;
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraBond,
-                                     pot.totalEnergy.intraBond, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.bond,
-                                     pot.totalEnergy.bond, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.angle,
-                                     pot.totalEnergy.angle, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.dihedral,
-                                     pot.totalEnergy.dihedral, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraNonbond,
-                                     pot.totalEnergy.intraNonbond, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.inter,
-                                     pot.totalEnergy.inter, EPSILON);
-  compare &=
-      num::approximatelyEqual(system->potential.totalEnergy.tailCorrection,
-                              pot.totalEnergy.tailCorrection, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.real,
-                                     pot.totalEnergy.real, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.self,
-                                     pot.totalEnergy.self, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.correction,
-                                     pot.totalEnergy.correction, EPSILON);
-  compare &= num::approximatelyEqual(system->potential.totalEnergy.recip,
-                                     pot.totalEnergy.recip, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraBond, pot.totalEnergy.intraBond, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.intraNonbond, pot.totalEnergy.intraNonbond, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.inter, pot.totalEnergy.inter, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.tailCorrection, pot.totalEnergy.tailCorrection, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.real, pot.totalEnergy.real, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.self, pot.totalEnergy.self, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.correction, pot.totalEnergy.correction, EPSILON);
+  compare &= num::approximatelyEqual(system->potential.totalEnergy.recip, pot.totalEnergy.recip, EPSILON);
 
-  if (!compare) {
+  if(!compare) {
     std::cout
         << "=================================================================\n"
-        << "Energy       INTRA B |       BOND |     ANGLE |     DIHEDRAL |     "
-           "INTRA NB |        INTER |           TC |         REAL |         "
-           "SELF |   CORRECTION |        RECIP"
+        << "Energy       INTRA B |     INTRA NB |        INTER |           TC |         REAL |         SELF |   CORRECTION |        RECIP"
         << std::endl
-        << "System: " << std::setw(12)
-        << system->potential.totalEnergy.intraBond << " | " << std::setw(12)
-        << system->potential.totalEnergy.bond << " | " << std::setw(12)
-        << system->potential.totalEnergy.angle << " | " << std::setw(12)
-        << system->potential.totalEnergy.dihedral << " | " << std::setw(12)
-        << system->potential.totalEnergy.intraNonbond << " | " << std::setw(12)
-        << system->potential.totalEnergy.inter << " | " << std::setw(12)
-        << system->potential.totalEnergy.tailCorrection << " | "
+        << "System: "
+        << std::setw(12) << system->potential.totalEnergy.intraBond << " | "
+        << std::setw(12) << system->potential.totalEnergy.intraNonbond << " | "
+        << std::setw(12) << system->potential.totalEnergy.inter << " | "
+        << std::setw(12) << system->potential.totalEnergy.tailCorrection << " | "
         << std::setw(12) << system->potential.totalEnergy.real << " | "
         << std::setw(12) << system->potential.totalEnergy.self << " | "
         << std::setw(12) << system->potential.totalEnergy.correction << " | "
         << std::setw(12) << system->potential.totalEnergy.recip << std::endl
-        << "Recalc: " << std::setw(12)
-        << system->potential.totalEnergy.intraBond << " | " << std::setw(12)
-        << pot.totalEnergy.bond << " | " << std::setw(12)
-        << pot.totalEnergy.angle << " | " << std::setw(12)
-        << pot.totalEnergy.dihedral << " | " << std::setw(12)
-        << pot.totalEnergy.intraNonbond << " | " << std::setw(12)
-        << pot.totalEnergy.inter << " | " << std::setw(12)
-        << pot.totalEnergy.tailCorrection << " | " << std::setw(12)
-        << pot.totalEnergy.real << " | " << std::setw(12)
-        << pot.totalEnergy.self << " | " << std::setw(12)
-        << pot.totalEnergy.correction << " | " << std::setw(12)
-        << pot.totalEnergy.recip << std::endl
+        << "Recalc: "
+        << std::setw(12) << pot.totalEnergy.intraBond << " | "
+        << std::setw(12) << pot.totalEnergy.intraNonbond << " | "
+        << std::setw(12) << pot.totalEnergy.inter << " | "
+        << std::setw(12) << pot.totalEnergy.tailCorrection << " | "
+        << std::setw(12) << pot.totalEnergy.real << " | "
+        << std::setw(12) << pot.totalEnergy.self << " | "
+        << std::setw(12) << pot.totalEnergy.correction << " | "
+        << std::setw(12) << pot.totalEnergy.recip << std::endl
         << "================================================================"
         << std::endl
         << std::endl;

--- a/src/moves/CrankShaft.h
+++ b/src/moves/CrankShaft.h
@@ -139,10 +139,7 @@ inline void CrankShaft::Accept(const uint rejectState, const ulong step) {
       // Add rest of energy.
       sysPotRef.boxEnergy[sourceBox] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[destBox] += newMol.GetEnergy();
-
-      sysPotRef.boxEnergy[sourceBox] -= calcEnRef.UpdateBondAngleDihe(oldMol);
-      sysPotRef.boxEnergy[destBox] += calcEnRef.UpdateBondAngleDihe(newMol);
-      // Add Reciprocal energy difference
+      //Add Reciprocal energy difference
       sysPotRef.boxEnergy[destBox].recip += recipDiff.energy;
       // Add correction energy
       sysPotRef.boxEnergy[sourceBox].correction -= correct_old;

--- a/src/moves/IntraSwap.h
+++ b/src/moves/IntraSwap.h
@@ -155,10 +155,7 @@ inline void IntraSwap::Accept(const uint rejectState, const ulong step) {
       // Add rest of energy.
       sysPotRef.boxEnergy[sourceBox] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[destBox] += newMol.GetEnergy();
-
-      sysPotRef.boxEnergy[sourceBox] -= calcEnRef.UpdateBondAngleDihe(oldMol);
-      sysPotRef.boxEnergy[destBox] += calcEnRef.UpdateBondAngleDihe(newMol);
-      // Add Reciprocal energy difference
+      //Add Reciprocal energy difference
       sysPotRef.boxEnergy[destBox].recip += recipDiff.energy;
       // Add correction energy
       sysPotRef.boxEnergy[sourceBox].correction -= correct_old;

--- a/src/moves/IntraTargetedSwap.h
+++ b/src/moves/IntraTargetedSwap.h
@@ -571,10 +571,7 @@ inline void IntraTargetedSwap::Accept(const uint rejectState,
       // Add rest of energy.
       sysPotRef.boxEnergy[box] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[box] += newMol.GetEnergy();
-
-      sysPotRef.boxEnergy[box] -= calcEnRef.UpdateBondAngleDihe(oldMol);
-      sysPotRef.boxEnergy[box] += calcEnRef.UpdateBondAngleDihe(newMol);
-      // Add Reciprocal energy
+      //Add Reciprocal energy
       sysPotRef.boxEnergy[box].recip += recipDiff.energy;
       // Add correction energy
       sysPotRef.boxEnergy[box].correction -= correct_old;

--- a/src/moves/MoleculeTransfer.h
+++ b/src/moves/MoleculeTransfer.h
@@ -192,10 +192,7 @@ inline void MoleculeTransfer::Accept(const uint rejectState, const ulong step) {
       // Add rest of energy.
       sysPotRef.boxEnergy[sourceBox] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[destBox] += newMol.GetEnergy();
-
-      sysPotRef.boxEnergy[sourceBox] -= calcEnRef.UpdateBondAngleDihe(oldMol);
-      sysPotRef.boxEnergy[destBox] += calcEnRef.UpdateBondAngleDihe(newMol);
-      // Add Reciprocal energy
+      //Add Reciprocal energy
       sysPotRef.boxEnergy[sourceBox].recip += recipLose.energy;
       sysPotRef.boxEnergy[destBox].recip += recipGain.energy;
       // Add correction energy

--- a/src/moves/Regrowth.h
+++ b/src/moves/Regrowth.h
@@ -151,11 +151,7 @@ inline void Regrowth::Accept(const uint rejectState, const ulong step) {
       // Add rest of energy.
       sysPotRef.boxEnergy[sourceBox] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[destBox] += newMol.GetEnergy();
-
-      sysPotRef.boxEnergy[sourceBox] -= calcEnRef.UpdateBondAngleDihe(oldMol);
-      sysPotRef.boxEnergy[destBox] += calcEnRef.UpdateBondAngleDihe(newMol);
-
-      // Add Reciprocal energy difference
+      //Add Reciprocal energy difference
       sysPotRef.boxEnergy[destBox].recip += recipDiff.energy;
       // Add correction energy
       sysPotRef.boxEnergy[sourceBox].correction -= correct_old;

--- a/src/moves/TargetedSwap.h
+++ b/src/moves/TargetedSwap.h
@@ -709,10 +709,7 @@ inline void TargetedSwap::Accept(const uint rejectState, const ulong step) {
       // Add rest of energy.
       sysPotRef.boxEnergy[sourceBox] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[destBox] += newMol.GetEnergy();
-
-      sysPotRef.boxEnergy[sourceBox] -= calcEnRef.UpdateBondAngleDihe(oldMol);
-      sysPotRef.boxEnergy[destBox] += calcEnRef.UpdateBondAngleDihe(newMol);
-      // Add Reciprocal energy
+      //Add Reciprocal energy
       sysPotRef.boxEnergy[sourceBox].recip += recipLose.energy;
       sysPotRef.boxEnergy[destBox].recip += recipGain.energy;
       // Add correction energy


### PR DESCRIPTION
Treating the energy members as public variables, and accessing them from multiple locations in the code is sloppy and difficult to maintain.  The EnergyType variables should be made private and only modified/set by the CalcEn function of each move.  This requires specifying one method signature for all the moves, instead of the current two formed approach.

Non-cbmc moves take a molecule index as the argument
CBMC moves pass a CBMC molecule object.

The molecule index can be used to retrieve a CBMC object, so it seems the molecule index should be passed to all methods as the argument, and CBMC moves can create/retrieve the CBMC molecule object internally.

Until this is finalized, this PR reverts the hacked together intraBonded terms.