### PR TITLE
Make NAMD_write more robust and informative on write errors

### DIFF
--- a/src/DCDlib.h
+++ b/src/DCDlib.h
@@ -16,9 +16,10 @@
 //#include "largefiles.h"  // must be first!
 //#include "common.h" // for int32 definition
 //#include "Vector.h"
+#include <cstring>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string>
 
 #include <iostream>
 


### PR DESCRIPTION
The current version of NAMD_write exits with a generic error message if the write() function returns an error.

This patch uses strerror() to print the text description of the error.

In addition, it retries up to 5 times, which is beneficial if there are transient errors.

Note that I was unable to reproduce this problem. The transient I/O errors disappeared once I wrote this patch. But the code is unchanged when the write() function succeeds. And the old code terminated immediately upon an error. So, I think there is very minimal if any risk in merging this patch even if it is incorrect.