### PR TITLE
Cleanup openmp commands.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install clang-openmp
-      run: apt install libomp-14-dev
+      run: sudo apt install -y libomp-14-dev
     - name: metamake
       run: ./metamake.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,5 +9,7 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+    - name: Install clang-openmp
+      run: apt install libomp-14-dev
     - name: metamake
       run: ./metamake.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ include_directories(src/GPU)
 #Out-of-source build
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+# clang-tidy
+set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,mpi-*,openmp-*)
+
 #Versioning
 set (GOMC_VERSION_MAJOR 2)
 set (GOMC_VERSION_MINOR 70)

--- a/src/EnsemblePreprocessor.h
+++ b/src/EnsemblePreprocessor.h
@@ -43,11 +43,6 @@ along with this program, also can be found at
 #define BOX_TOTAL 1
 #endif
 
-// Get GCC version
-// 9.3.0 will become 90300 here
-#define GCC_VERSION                                                            \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
 // Error flags
 namespace errors {
 const int READ_ERROR = -1;

--- a/src/Ewald.cpp
+++ b/src/Ewald.cpp
@@ -421,15 +421,9 @@ double Ewald::MolReciprocal(XYZArray const &molCoords, const uint molIndex,
                          sumInew[box], energyRecipNew, box);
 #else
 #ifdef _OPENMP
-#if GCC_VERSION >= 90000
-#pragma omp parallel for default(none) shared(lambdaCoef, length, molCoords, \
-    startAtom, thisKind, box) \
+#pragma omp parallel for default(none) shared(lambdaCoef, molCoords, \
+    startAtom, thisKind) firstprivate(box, length) \
 reduction(+:energyRecipNew)
-#else
-#pragma omp parallel for default(none) shared(lambdaCoef, length, molCoords, \
-    startAtom, thisKind) \
-reduction(+:energyRecipNew)
-#endif
 #endif
     for (int i = 0; i < (int)imageSizeRef[box]; i++) {
       double sumRealNew = 0.0;
@@ -495,13 +489,8 @@ double Ewald::SwapDestRecip(const cbmc::TrialMol &newMol, const uint box,
 #else
     uint startAtom = mols.MolStart(molIndex);
 #ifdef _OPENMP
-#if GCC_VERSION >= 90000
-#pragma omp parallel for default(none) shared(length, molCoords, startAtom, \
-thisKind, box) reduction(+:energyRecipNew)
-#else
-#pragma omp parallel for default(none) shared(length, molCoords, startAtom, \
-thisKind) reduction(+:energyRecipNew)
-#endif
+#pragma omp parallel for default(none) shared(molCoords, thisKind) \
+reduction(+:energyRecipNew) firstprivate(length, box, startAtom)
 #endif
     for (int i = 0; i < (int)imageSizeRef[box]; i++) {
       double sumRealNew = 0.0;
@@ -556,15 +545,8 @@ double Ewald::ChangeLambdaRecip(XYZArray const &molCoords,
         sumRnew[box], sumInew[box], energyRecipNew, lambdaCoef, box);
 #else
 #ifdef _OPENMP
-#if GCC_VERSION >= 90000
-#pragma omp parallel for default(none) shared(lambdaCoef, length, molCoords, \
-    startAtom, thisKind, box) \
-reduction(+:energyRecipNew)
-#else
-#pragma omp parallel for default(none) shared(lambdaCoef, length, molCoords, \
-    startAtom, thisKind) \
-reduction(+:energyRecipNew)
-#endif
+#pragma omp parallel for default(none) shared(lambdaCoef, molCoords, thisKind) \
+firstprivate(box, length, startAtom) reduction(+:energyRecipNew)
 #endif
     for (int i = 0; i < (int)imageSizeRef[box]; i++) {
       double sumRealNew = 0.0;
@@ -612,15 +594,9 @@ void Ewald::ChangeRecip(Energy *energyDiff, Energy &dUdL_Coul,
   std::fill_n(energyRecip, lambdaSize, 0.0);
 
 #if defined _OPENMP && _OPENMP >= 201511 // check if OpenMP version is 4.5
-#if GCC_VERSION >= 90000
-#pragma omp parallel for default(none) shared(lambda_Coul, lambdaSize, \
-  length, startAtom, box, iState) \
+#pragma omp parallel for default(none) shared(lambda_Coul) \
+firstprivate(lambdaSize, length, startAtom, box, iState) \
 reduction(+:energyRecip[:lambdaSize])
-#else
-#pragma omp parallel for default(none) shared(lambda_Coul, lambdaSize, \
-  length, startAtom) \
-reduction(+:energyRecip[:lambdaSize])
-#endif
 #endif
   for (int i = 0; i < (int)imageSizeRef[box]; i++) {
     double sumReal = 0.0;
@@ -693,15 +669,8 @@ double Ewald::SwapSourceRecip(const cbmc::TrialMol &oldMol, const uint box,
 #else
     uint startAtom = mols.MolStart(molIndex);
 #ifdef _OPENMP
-#if GCC_VERSION >= 90000
-#pragma omp parallel for default(none) shared(length, molCoords, startAtom, \
-    thisKind, box) \
-reduction(+:energyRecipNew)
-#else
-#pragma omp parallel for default(none) shared(length, molCoords, startAtom, \
-    thisKind) \
-reduction(+:energyRecipNew)
-#endif
+#pragma omp parallel for default(none) shared(molCoords, thisKind) \
+firstprivate(length, box, startAtom) reduction(+:energyRecipNew)
 #endif
     for (int i = 0; i < (int)imageSizeRef[box]; i++) {
       double sumRealNew = 0.0;

--- a/src/XYZArray.h
+++ b/src/XYZArray.h
@@ -370,11 +370,7 @@ inline void XYZArray::SetRange(const uint start, const uint stop,
 
 inline void XYZArray::ResetRange(const uint val, const uint stop) {
 #ifdef _OPENMP
-#if GCC_VERSION >= 90000
-#pragma omp parallel default(none) shared(val, stop)
-#else
-#pragma omp parallel default(none)
-#endif
+#pragma omp parallel default(none) firstprivate(val, stop)
 #endif
   {
     memset(this->x, val, stop * sizeof(double));
@@ -487,11 +483,7 @@ inline void XYZArray::ScaleAll(const double val) { ScaleRange(0, count, val); }
 inline void XYZArray::CopyRange(XYZArray &dest, const uint srcIndex,
                                 const uint destIndex, const uint len) const {
 #ifdef _OPENMP
-#if GCC_VERSION >= 90000
-#pragma omp parallel default(none) shared(dest, len, srcIndex, destIndex)
-#else
-#pragma omp parallel default(none) shared(dest)
-#endif
+#pragma omp parallel default(none) firstprivate(srcIndex, destIndex, len) shared(dest)
 #endif
   {
     memcpy(dest.x + destIndex, x + srcIndex, len * sizeof(double));


### PR DESCRIPTION
1. There is no need for checking `gcc` version. `firstprivate()` works on pre/post openmp 4.5; https://gcc.gnu.org/gcc-9/porting_to.html
2. I also added clang-tidy requirement to `cmake`. Meaning the code has to match clang-tidy's standards to even compile. `set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,mpi-*,openmp-*)` does this. The first part (`-*`) disables all checks, and then adds any checks that starts with `mpi` and `openmp`. Code currently passes for these two. Once we do more clean ups we can add more check here.