### PR TITLE
Move some needed code outside an if block

### DIFF
--- a/src/EnergyTypes.h
+++ b/src/EnergyTypes.h
@@ -530,11 +530,11 @@ inline std::ostream &operator<<(std::ostream &out, Energy &en) {
         << "\tTotal Electric: " << en.totalElect << "  Real: " << en.real
         << "  Recip: " << en.recip << "  Self: " << en.self
         << "  Correction: " << en.correction;
-
-    // Restore ostream settings to prior value
-    out << std::setprecision(ss);
-    out.flags(ff);
   }
+
+  // Restore ostream settings to prior value
+  out << std::setprecision(ss);
+  out.flags(ff);
   return out;
 }
 #endif


### PR DESCRIPTION
When printing energies using the << operator, which is available only in debug mode, some ostream settings might not be reset to their original values because some code was placed inside an if block that should always executed.