### PR TITLE
Fix #486 Resolve OOB read in IsMoleculeInBox when not found

### DIFF
--- a/src/MoleculeLookup.h
+++ b/src/MoleculeLookup.h
@@ -120,7 +120,8 @@ public:
                   molIdx) -
         molLookup;
 
-    return ((molLookup[index] == molIdx));
+    // std::find returns the last value if not found, so then return false
+    return (index < boxAndKindStart[box * numKinds + kindIdx + 1]);
   }
 
   // determine if atom is in this box or not// uses global atom index


### PR DESCRIPTION
See description on Pull Request. The patch works as follows:

std::find( ) looks at the values in the specified range of the array and returns the last, which is not in the array. (For instance, if your array length is 100, you pass 0 and 100 and it returns 100 if not found, but a[100] is not in the array.) If it finds the value, it returns the appropriate index.

The code checks that the index is in the correct range (less than the upper bound). If it matches the upper bound, then you return false.