### PR TITLE
Change Mersenne Twister function call usage so that icc and gcc compilations produce matching results

### DIFF
--- a/src/CalculateEnergy.cpp
+++ b/src/CalculateEnergy.cpp
@@ -1372,9 +1372,9 @@ void CalculateEnergy::CalculateTorque(std::vector<uint> &moleculeIndex,
     double *torquez = molTorque.z;
 
 #if defined _OPENMP
-#pragma omp parallel for default(none) \
-shared(atomForce, atomForceRec, com, coordinates, moleculeIndex, torquex, torquey, torquez) \
-firstprivate(box)
+#pragma omp parallel for default(none)                                         \
+    shared(atomForce, atomForceRec, com, coordinates, moleculeIndex, torquex,  \
+           torquey, torquez) firstprivate(box)
 #endif
     for (int m = 0; m < (int)moleculeIndex.size(); m++) {
       int mIndex = moleculeIndex[m];

--- a/src/ConsoleOutput.cpp
+++ b/src/ConsoleOutput.cpp
@@ -319,7 +319,7 @@ void ConsoleOutput::PrintEnergyTitle() {
   std::string title = "ETITLE:";
   size_t loc = title.length();
   title += "STEP";
-  title.insert(loc, elementWidth-title.length(), ' ');
+  title.insert(loc, elementWidth - title.length(), ' ');
   printElement(title, elementWidth);
 
   printElement("TOTAL", elementWidth);
@@ -341,7 +341,7 @@ void ConsoleOutput::PrintStatisticTitle() {
     std::string title = "STITLE:";
     size_t loc = title.length();
     title += "STEP";
-    title.insert(loc, elementWidth-title.length(), ' ');
+    title.insert(loc, elementWidth - title.length(), ' ');
     printElement(title, elementWidth);
   }
 
@@ -386,7 +386,7 @@ void ConsoleOutput::PrintMoveTitle() {
   std::string title = "MTITLE:";
   size_t loc = title.length();
   title += "STEP";
-  title.insert(loc, elementWidth-title.length(), ' ');
+  title.insert(loc, elementWidth - title.length(), ' ');
   printElement(title, elementWidth);
   if (var->Performed(mv::DISPLACE)) {
     printElement("DISTRY", elementWidth);

--- a/src/Coordinates.cpp
+++ b/src/Coordinates.cpp
@@ -103,14 +103,14 @@ void Coordinates::TranslateRand(XYZArray &dest, XYZ &newCOM, uint &pStart,
   newCOM = boxDimRef.WrapPBC(newCOM, b);
 }
 
-// Rotate by a random amount.
+// Rotate by a random amount
 void Coordinates::RotateRand(XYZArray &dest, uint &pStart, uint &pLen,
                              const uint m, const uint b, const double max) {
   // Rotate (-max, max) radians about a uniformly random vector
   // Not uniformly random, but symmetrical wrt detailed balance
   // Note: In order for gcc to produce the same results as the Intel compiler,
-  //       we need to create variables instead of generating these random
-  //       function calls as parameters to the function call.
+  //       we need to create variables instead of using these calls to random
+  //       functions as parameters to the FromAxisAngle function call.
   double theta = prngRef.Sym(max);
   XYZ axis = prngRef.PickOnUnitSphere();
   RotationMatrix matrix = RotationMatrix::FromAxisAngle(theta, axis);

--- a/src/Coordinates.cpp
+++ b/src/Coordinates.cpp
@@ -108,8 +108,12 @@ void Coordinates::RotateRand(XYZArray &dest, uint &pStart, uint &pLen,
                              const uint m, const uint b, const double max) {
   // Rotate (-max, max) radians about a uniformly random vector
   // Not uniformly random, but symmetrical wrt detailed balance
-  RotationMatrix matrix = RotationMatrix::FromAxisAngle(
-      prngRef.Sym(max), prngRef.PickOnUnitSphere());
+  // Note: In order for gcc to produce the same results as the Intel compiler,
+  //       we need to create variables instead of generating these random
+  //       function calls as parameters to the function call.
+  double theta = prngRef.Sym(max);
+  XYZ axis = prngRef.PickOnUnitSphere();
+  RotationMatrix matrix = RotationMatrix::FromAxisAngle(theta, axis);
 
   XYZ center = comRef.Get(m);
   uint stop = 0;

--- a/src/GPU/CalculateForceCUDAKernel.cu
+++ b/src/GPU/CalculateForceCUDAKernel.cu
@@ -664,9 +664,9 @@ BoxForceGPU(int *gpu_cellStartIndex, int *gpu_cellVector, int *gpu_neighborList,
         gpu_cellVector[shr_neighborCellStartIndex + neighborParticleIndex];
 
     // We don't process the same pair of cells twice, so we just need to check
-	// to be sure we have different molecules. The exception is when the two
-	// cells are the same, then we need to skip some pairs of molecules so we
-	// don't double count any pairs.
+    // to be sure we have different molecules. The exception is when the two
+    // cells are the same, then we need to skip some pairs of molecules so we
+    // don't double count any pairs.
     int mA = gpu_particleMol[currentParticle];
     int mB = gpu_particleMol[neighborParticle];
     bool skip = mA == mB || (shr_sameCell && mA > mB);

--- a/src/PRNG.h
+++ b/src/PRNG.h
@@ -105,9 +105,9 @@ public:
   }
 
   void FillWithRandomInCavity(XYZ &loc, XYZ const &cavDim) {
-    double x = SymExc(cavDim.x / 2.0);
-    double y = SymExc(cavDim.y / 2.0);
-    double z = SymExc(cavDim.z / 2.0);
+    double x = Sym(cavDim.x / 2.0);
+    double y = Sym(cavDim.y / 2.0);
+    double z = Sym(cavDim.z / 2.0);
     XYZ temp(x, y, z);
     loc = temp;
   }
@@ -116,11 +116,11 @@ public:
   // of cavCenter
   void FillWithRandomInCavity(XYZArray &loc, const uint len, XYZ const &cavDim,
                               XYZ const &cavCenter) {
-    // generate random trial in range of (-cavDim/2, +cavDim/2)
+    // generate random trial in range of [-cavDim/2, +cavDim/2]
     for (uint i = 0; i < len; ++i) {
-      double x = SymExc(cavDim.x / 2.0);
-      double y = SymExc(cavDim.y / 2.0);
-      double z = SymExc(cavDim.z / 2.0);
+      double x = Sym(cavDim.x / 2.0);
+      double y = Sym(cavDim.y / 2.0);
+      double z = Sym(cavDim.z / 2.0);
       loc.Set(i, x, y, z);
     }
     // Shift by center

--- a/src/PRNG.h
+++ b/src/PRNG.h
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
 GPU OPTIMIZED MONTE CARLO (GOMC) 2.75
 Copyright (C) 2022 GOMC Group
@@ -46,11 +45,11 @@ public:
   // Standard double generation on [0,1.0]
   double operator()() { return (*gen)(); }
 
-  // Generate a double on a [0,b]
-  double rand(double const bound) { return gen->rand(bound); }
+  // Generate a double on [0,bound]
+  double rand(const double bound) { return gen->rand(bound); }
 
-  // Generate a double on a [0,b)
-  double randExc(double const bound) { return gen->randExc(bound); }
+  // Generate a double on [0,bound)
+  double randExc(const double bound) { return gen->randExc(bound); }
 
   // Generate an unsigned int on [0,bound]
   uint randInt(const uint bound) { return (uint)(gen->randInt(bound)); }
@@ -58,15 +57,15 @@ public:
   // Generate an unsigned int on [0,bound)
   uint randIntExc(const uint bound) { return (uint)(gen->randInt(bound - 1)); }
 
-  // Generates number on (-bound,bound)
-  double Sym(double bound) { return 2 * bound * gen->rand() - bound; }
+  // Generates a double on [-bound,bound]
+  double Sym(const double bound) { return gen->rand(2.0 * bound) - bound; }
 
   /////////////////////////////
   //   GENERATION FUNCTIONS  //
   /////////////////////////////
 
-  XYZ SymXYZ(double bound) {
-    double bound2 = 2 * bound;
+  XYZ SymXYZ(const double bound) {
+    double bound2 = 2.0 * bound;
     return XYZ(gen->rand(bound2) - bound, gen->rand(bound2) - bound,
                gen->rand(bound2) - bound);
   }
@@ -148,8 +147,7 @@ public:
   XYZ PickOnUnitSphere() {
     // picking phi uniformly will cluster points at poles
     // pick u = cos(phi) uniformly instead
-    double u = gen->rand(2.0);
-    u -= 1.0;
+    double u = Sym(1.0);
     double theta = gen->randExc(2.0 * M_PI);
     double rootTerm = sqrt(1.0 - u * u);
     return XYZ(rootTerm * cos(theta), rootTerm * sin(theta), u);
@@ -159,8 +157,7 @@ public:
   void PickArbDist(uint &pick, double &subDraw, double const *const w,
                    const double Wt, const uint len) {
     double sum = 0.0, prevSum = 0.0, draw = rand(Wt);
-    pick = 0;
-    for (; pick < len && sum < draw; ++pick) {
+    for (pick = 0; pick < len && sum < draw; ++pick) {
       prevSum = sum;
       sum += w[pick];
     }
@@ -171,7 +168,8 @@ public:
 
   // Pick an integer in range 0, n given a list of weights, and their sum
   // totalWeight
-  uint PickWeighted(const double *weights, const uint n, double totalWeight) {
+  uint PickWeighted(const double *weights, const uint n,
+                    const double totalWeight) {
     double draw = rand(totalWeight);
     double sum = 0.0;
     for (uint i = 0; i < n; ++i) {
@@ -185,7 +183,7 @@ public:
       lastZero = i;
     }
     lastZero--;
-    if (std::abs(draw - totalWeight) < 0.001) {
+    if (std::fabs(draw - totalWeight) < 0.001) {
       return lastZero;
     }
 

--- a/src/XYZArray.h
+++ b/src/XYZArray.h
@@ -483,7 +483,8 @@ inline void XYZArray::ScaleAll(const double val) { ScaleRange(0, count, val); }
 inline void XYZArray::CopyRange(XYZArray &dest, const uint srcIndex,
                                 const uint destIndex, const uint len) const {
 #ifdef _OPENMP
-#pragma omp parallel default(none) firstprivate(srcIndex, destIndex, len) shared(dest)
+#pragma omp parallel default(none) firstprivate(srcIndex, destIndex, len)      \
+    shared(dest)
 #endif
   {
     memcpy(dest.x + destIndex, x + srcIndex, len * sizeof(double));

--- a/src/moves/IntraMoleculeExchange1.h
+++ b/src/moves/IntraMoleculeExchange1.h
@@ -271,11 +271,16 @@ inline uint IntraMoleculeExchange1::PickMolInCav() {
   uint state = mv::fail_state::NO_FAIL;
   // pick a random location in source box
   XYZ axis = boxDimRef.GetAxis(sourceBox);
-  XYZ temp(prng.randExc(axis.x), prng.randExc(axis.y), prng.randExc(axis.z));
+  // Doing the rand calls outside the function call avoids a gcc compiler issue
+  double x = prng.randExc(axis.x);
+  double y = prng.randExc(axis.y);
+  double z = prng.randExc(axis.z);
+  XYZ temp(x, y, z);
   // Use to find small molecule
   centerA = temp;
   // Pick random vector and find two vectors that are perpendicular to V1
-  SetBasis(cavA, prng.RandomUnitVect());
+  XYZ cavVect = prng.RandomUnitVect();
+  SetBasis(cavA, cavVect);
   // Calculate inverse matrix for cavity, here Inverse = transpose
   TransposeMatrix(invCavA, cavA);
   // Find the small molecule kind in the cavityA
@@ -311,7 +316,8 @@ inline uint IntraMoleculeExchange1::PickMolInCav() {
     centerB = comCurrRef.Get(molIndexB[0]);
     // Set the V1 to the the backbone of the large molecule
     if (molRef.NumAtoms(kindL) == 1) {
-      SetBasis(cavB, prng.RandomUnitVect());
+      cavVect = prng.RandomUnitVect();
+      SetBasis(cavB, cavVect);
     } else {
       uint start = molRef.MolStart(molIndexB[0]) + largeBB[0];
       uint end = molRef.MolStart(molIndexB[0]) + largeBB[1];

--- a/src/moves/IntraMoleculeExchange2.h
+++ b/src/moves/IntraMoleculeExchange2.h
@@ -141,7 +141,8 @@ inline uint IntraMoleculeExchange2::PickMolInCav() {
     centerA = comCurrRef.Get(pickedS);
     // If we want to orient the cavity with backbone of picked small mol
     if (molRef.NumAtoms(kindS) == 1) {
-      SetBasis(cavA, prng.RandomUnitVect());
+      XYZ cavVect = prng.RandomUnitVect();
+      SetBasis(cavA, cavVect);
     } else {
       uint start = molRef.MolStart(pickedS) + smallBB[0];
       uint end = molRef.MolStart(pickedS) + smallBB[1];
@@ -198,7 +199,8 @@ inline uint IntraMoleculeExchange2::PickMolInCav() {
     centerB = comCurrRef.Get(molIndexB[0]);
     // Set the V1 to the the backbone of the large molecule
     if (molRef.NumAtoms(kindL) == 1) {
-      SetBasis(cavB, prng.RandomUnitVect());
+      XYZ cavVect = prng.RandomUnitVect();
+      SetBasis(cavB, cavVect);
     } else {
       uint start = molRef.MolStart(molIndexB[0]) + largeBB[0];
       uint end = molRef.MolStart(molIndexB[0]) + largeBB[1];

--- a/src/moves/IntraMoleculeExchange3.h
+++ b/src/moves/IntraMoleculeExchange3.h
@@ -106,7 +106,8 @@ inline uint IntraMoleculeExchange3::PickMolInCav() {
   if (state == mv::fail_state::NO_FAIL) {
     centerA = comCurrRef.Get(pickedS);
     // Pick random vector and find two vectors that are perpendicular to V1
-    SetBasis(cavA, prng.RandomUnitVect());
+    XYZ cavVect = prng.RandomUnitVect();
+    SetBasis(cavA, cavVect);
     // Calculate inverse matrix for cav here Inv = transpose
     TransposeMatrix(invCavA, cavA);
 
@@ -157,7 +158,8 @@ inline uint IntraMoleculeExchange3::PickMolInCav() {
     uint start = molRef.MolStart(molIndexB[0]) + largeBB[0];
     centerB = coordCurrRef.Get(start);
     // Set V1 to a random vector and calculate two vector perpendicular to V1
-    SetBasis(cavB, prng.RandomUnitVect());
+    XYZ cavVect = prng.RandomUnitVect();
+    SetBasis(cavB, cavVect);
     // Calculate inverse matrix for cav. Here Inv = Transpose
     TransposeMatrix(invCavB, cavB);
     if (exchangeRatio == 1) {

--- a/src/moves/IntraSwap.h
+++ b/src/moves/IntraSwap.h
@@ -155,7 +155,7 @@ inline void IntraSwap::Accept(const uint rejectState, const ulong step) {
       // Add rest of energy.
       sysPotRef.boxEnergy[sourceBox] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[destBox] += newMol.GetEnergy();
-      //Add Reciprocal energy difference
+      // Add Reciprocal energy difference
       sysPotRef.boxEnergy[destBox].recip += recipDiff.energy;
       // Add correction energy
       sysPotRef.boxEnergy[sourceBox].correction -= correct_old;

--- a/src/moves/IntraTargetedSwap.h
+++ b/src/moves/IntraTargetedSwap.h
@@ -571,7 +571,7 @@ inline void IntraTargetedSwap::Accept(const uint rejectState,
       // Add rest of energy.
       sysPotRef.boxEnergy[box] -= oldMol.GetEnergy();
       sysPotRef.boxEnergy[box] += newMol.GetEnergy();
-      //Add Reciprocal energy
+      // Add Reciprocal energy
       sysPotRef.boxEnergy[box].recip += recipDiff.energy;
       // Add correction energy
       sysPotRef.boxEnergy[box].correction -= correct_old;

--- a/src/moves/MoleculeExchange1.h
+++ b/src/moves/MoleculeExchange1.h
@@ -292,11 +292,16 @@ inline uint MoleculeExchange1::PickMolInCav() {
   uint state = mv::fail_state::NO_FAIL;
   // pick a random location in dense phase
   XYZ axis = boxDimRef.GetAxis(sourceBox);
-  XYZ temp(prng.randExc(axis.x), prng.randExc(axis.y), prng.randExc(axis.z));
+  // Doing the rand calls outside the function call avoids a gcc compiler issue
+  double x = prng.randExc(axis.x);
+  double y = prng.randExc(axis.y);
+  double z = prng.randExc(axis.z);
+  XYZ temp(x, y, z);
   // Use to shift the new inserted molecule
   center = temp;
   // Pick random vector and find two vectors that are perpendicular to V1
-  SetBasis(cavA, prng.RandomUnitVect());
+  XYZ cavVect = prng.RandomUnitVect();
+  SetBasis(cavA, cavVect);
   // Calculate inverse matrix for cav here Inv = transpose
   TransposeMatrix(invCavA, cavA);
 
@@ -338,7 +343,8 @@ inline uint MoleculeExchange1::ReplaceMolecule() {
   if (state == mv::fail_state::NO_FAIL) {
     // Set the V1 to the backbone of the large molecule
     if (molRef.NumAtoms(kindL) == 1) {
-      SetBasis(cavA, prng.RandomUnitVect());
+      XYZ cavVect = prng.RandomUnitVect();
+      SetBasis(cavA, cavVect);
     } else {
       uint start = molRef.MolStart(molIndexA[0]) + largeBB[0];
       uint end = molRef.MolStart(molIndexA[0]) + largeBB[1];

--- a/src/moves/MoleculeExchange2.h
+++ b/src/moves/MoleculeExchange2.h
@@ -205,7 +205,7 @@ inline uint MoleculeExchange2::ReplaceMolecule() {
     // Set the V1 to the backbone of the large molecule
     if (molRef.NumAtoms(kindL) == 1) {
       XYZ cavVect = prng.RandomUnitVect();
-      SetBasis(cavA, cavVect());
+      SetBasis(cavA, cavVect);
     } else {
       uint start = molRef.MolStart(molIndexA[0]) + largeBB[0];
       uint end = molRef.MolStart(molIndexA[0]) + largeBB[1];

--- a/src/moves/MoleculeExchange2.h
+++ b/src/moves/MoleculeExchange2.h
@@ -140,7 +140,8 @@ inline uint MoleculeExchange2::PickMolInCav() {
     center = comCurrRef.Get(pickedS);
     // If we want to orient the cavity with backbone of picked small mol
     if (molRef.NumAtoms(kindS) == 1) {
-      SetBasis(cavA, prng.RandomUnitVect());
+      XYZ cavVect = prng.RandomUnitVect();
+      SetBasis(cavA, cavVect);
     } else {
       uint start = molRef.MolStart(pickedS) + smallBB[0];
       uint end = molRef.MolStart(pickedS) + smallBB[1];
@@ -203,7 +204,8 @@ inline uint MoleculeExchange2::ReplaceMolecule() {
   if (state == mv::fail_state::NO_FAIL) {
     // Set the V1 to the backbone of the large molecule
     if (molRef.NumAtoms(kindL) == 1) {
-      SetBasis(cavA, prng.RandomUnitVect());
+      XYZ cavVect = prng.RandomUnitVect();
+      SetBasis(cavA, cavVect());
     } else {
       uint start = molRef.MolStart(molIndexA[0]) + largeBB[0];
       uint end = molRef.MolStart(molIndexA[0]) + largeBB[1];

--- a/src/moves/MoleculeExchange3.h
+++ b/src/moves/MoleculeExchange3.h
@@ -105,7 +105,8 @@ inline uint MoleculeExchange3::PickMolInCav() {
   if (state == mv::fail_state::NO_FAIL) {
     center = comCurrRef.Get(pickedS);
     // Pick random vector and find two vectors that are perpendicular to V1
-    SetBasis(cavA, prng.RandomUnitVect());
+    XYZ cavVect = prng.RandomUnitVect();
+    SetBasis(cavA, cavVect);
     // Calculate inverse matrix for cav here Inv = transpose
     TransposeMatrix(invCavA, cavA);
 
@@ -160,7 +161,8 @@ inline uint MoleculeExchange3::ReplaceMolecule() {
 
   if (state == mv::fail_state::NO_FAIL) {
     // Set V1 to a random vector and calculate two vector perpendicular to V1
-    SetBasis(cavA, prng.RandomUnitVect());
+    XYZ cavVect = prng.RandomUnitVect();
+    SetBasis(cavA, cavVect);
     // Calculate inverse matrix for cav. Here Inv = Transpose
     TransposeMatrix(invCavA, cavA);
     // use the predefine atom in kindL as the center


### PR DESCRIPTION
Fix issue #498. It turns out that gcc is not compiling the code correctly when we are making a call to a Mersenne Twister rand() function and using the output as a function parameter. In other words, the call to rand() appears in the function call. This causes the icc and gcc code to generate different results.

This happens with gcc 7.3. Might be fixed in a newer version of gcc, but need to produce a correct sequence of random numbers for any compiler, hence this patch.