### PR TITLE
Check all restart files to make sure Restart is true

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -1769,8 +1769,26 @@ void ConfigSetup::verifyInputs(void) {
   }
 
   if (in.restart.restartFromCheckpoint && !in.restart.enable) {
-    std::cout << "Error: Checkpoint cannot be used without Restart true!"
-              << std::endl;
+    std::cout << "Error: Restarting from checkpoint file requires"
+              << " Restart true!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if (in.restart.restartFromBinaryCoorFile && !in.restart.enable) {
+    std::cout << "Error: Restarting from binary coordinate file(s) requires"
+              << " Restart true!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if (in.restart.restartFromBinaryVelFile && !in.restart.enable) {
+    std::cout << "Error: Restarting from binary velocity file(s) requires"
+              << " Restart true!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if (in.restart.restartFromXSCFile && !in.restart.enable) {
+    std::cout << "Error: Restarting from extended system file(s) requires"
+              << " Restart true!" << std::endl;
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
Resolves Issue #500 by making sure that a user who specifies a restart file in the config file can't run without also setting Restart to true.

This solution is more flexible in handling user errors in the config file than just setting Restart to true in these cases.