### PR TITLE
comment out clang tidy and ensure src has subvolume before exiting on…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories(src/GPU)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # clang-tidy
-set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,mpi-*,openmp-*)
+#set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,mpi-*,openmp-*)
 
 #Versioning
 set (GOMC_VERSION_MAJOR 2)

--- a/src/moves/TargetedSwap.h
+++ b/src/moves/TargetedSwap.h
@@ -421,7 +421,7 @@ inline uint TargetedSwap::GetBoxPairAndMol(const double subDraw,
   state = PickMolInSubVolume();
 
 #if ENSEMBLE == GCMC
-  if (state == mv::fail_state::NO_MOL_OF_KIND_IN_BOX && sourceBox == mv::BOX1) {
+  if (state == mv::fail_state::NO_MOL_OF_KIND_IN_BOX && sourceBox == mv::BOX1 && hasSubVolume[sourceBox]) {
     std::cout << "Error: There are no molecules of kind "
               << molRef.kinds[kindIndex].name << " left in reservoir.\n";
     exit(EXIT_FAILURE);


### PR DESCRIPTION
Development branch doesnt build because of clangtidy.  I commented it out.
Also, targeted swap has some logic where it deduces which box to use depending on where the subvolume.

However, if the subvolume doesnt have a certain molecule, GOMC terminates thinking the resevoir is empty.