### PR TITLE
Use omp sections to remove redundant memset/memcpy calls

### DIFF
--- a/src/Ewald.cpp
+++ b/src/Ewald.cpp
@@ -225,12 +225,17 @@ void Ewald::BoxReciprocalSetup(uint box, XYZArray const &molCoords) {
         hsqr[box], currentEnergyRecip[box], box);
 #else
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(box)
-#endif
+#pragma omp parallel sections default(none) shared(box)
     {
+#pragma omp section
       std::memset(sumRnew[box], 0.0, sizeof(double) * imageSize[box]);
+#pragma omp section
       std::memset(sumInew[box], 0.0, sizeof(double) * imageSize[box]);
     }
+#else
+    std::memset(sumRnew[box], 0.0, sizeof(double) * imageSize[box]);
+    std::memset(sumInew[box], 0.0, sizeof(double) * imageSize[box]);
+#endif
 
     while (thisMol != end) {
       MoleculeKind const &thisKind = mols.GetKind(*thisMol);
@@ -307,12 +312,17 @@ void Ewald::BoxReciprocalSums(uint box, XYZArray const &molCoords) {
                              sumInew[box], currentEnergyRecip[box], box);
 #else
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(box)
-#endif
+#pragma omp parallel sections default(none) shared(box)
     {
+#pragma omp section
       std::memset(sumRnew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+#pragma omp section
       std::memset(sumInew[box], 0.0, sizeof(double) * imageSizeRef[box]);
     }
+#else
+    std::memset(sumRnew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+    std::memset(sumInew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+#endif
 
     while (thisMol != end) {
       MoleculeKind const &thisKind = mols.GetKind(*thisMol);
@@ -1011,17 +1021,32 @@ void Ewald::RecipCountInit(uint box, BoxDimensions const &boxAxes) {
 // back up reciprocal value to Ref (will be called during initialization)
 void Ewald::SetRecipRef(uint box) {
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(box)
-#endif
+#pragma omp parallel sections default(none) shared(box)
   {
+#pragma omp section
     std::memcpy(sumRref[box], sumRnew[box], sizeof(double) * imageSize[box]);
+#pragma omp section
     std::memcpy(sumIref[box], sumInew[box], sizeof(double) * imageSize[box]);
+#pragma omp section
     std::memcpy(kxRef[box], kx[box], sizeof(double) * imageSize[box]);
+#pragma omp section
     std::memcpy(kyRef[box], ky[box], sizeof(double) * imageSize[box]);
+#pragma omp section
     std::memcpy(kzRef[box], kz[box], sizeof(double) * imageSize[box]);
+#pragma omp section
     std::memcpy(hsqrRef[box], hsqr[box], sizeof(double) * imageSize[box]);
+#pragma omp section
     std::memcpy(prefactRef[box], prefact[box], sizeof(double) * imageSize[box]);
   }
+#else
+  std::memcpy(sumRref[box], sumRnew[box], sizeof(double) * imageSize[box]);
+  std::memcpy(sumIref[box], sumInew[box], sizeof(double) * imageSize[box]);
+  std::memcpy(kxRef[box], kx[box], sizeof(double) * imageSize[box]);
+  std::memcpy(kyRef[box], ky[box], sizeof(double) * imageSize[box]);
+  std::memcpy(kzRef[box], kz[box], sizeof(double) * imageSize[box]);
+  std::memcpy(hsqrRef[box], hsqr[box], sizeof(double) * imageSize[box]);
+  std::memcpy(prefactRef[box], prefact[box], sizeof(double) * imageSize[box]);
+#endif
 #ifdef GOMC_CUDA
   CopyCurrentToRefCUDA(ff.particles->getCUDAVars(), box, imageSize[box]);
 #endif
@@ -1417,12 +1442,17 @@ void Ewald::CopyRecip(uint box) {
     return;
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(box)
-#endif
+#pragma omp parallel sections default(none) shared(box)
   {
+#pragma omp section
     std::memcpy(sumRnew[box], sumRref[box], sizeof(double) * imageSizeRef[box]);
+#pragma omp section
     std::memcpy(sumInew[box], sumIref[box], sizeof(double) * imageSizeRef[box]);
   }
+#else
+  std::memcpy(sumRnew[box], sumRref[box], sizeof(double) * imageSizeRef[box]);
+  std::memcpy(sumInew[box], sumIref[box], sizeof(double) * imageSizeRef[box]);
+#endif
 #ifdef GOMC_CUDA
   CopyRefToNewCUDA(ff.particles->getCUDAVars(), box, imageSizeRef[box]);
 #endif

--- a/src/EwaldCached.cpp
+++ b/src/EwaldCached.cpp
@@ -98,12 +98,17 @@ void EwaldCached::BoxReciprocalSetup(uint box, XYZArray const &molCoords) {
     MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(box)
-#endif
+#pragma omp parallel sections default(none) shared(box)
     {
+#pragma omp section
       std::memset(sumRnew[box], 0.0, sizeof(double) * imageSize[box]);
+#pragma omp section
       std::memset(sumInew[box], 0.0, sizeof(double) * imageSize[box]);
     }
+#else
+    std::memset(sumRnew[box], 0.0, sizeof(double) * imageSize[box]);
+    std::memset(sumInew[box], 0.0, sizeof(double) * imageSize[box]);
+#endif
 
     while (thisMol != end) {
       MoleculeKind const &thisKind = mols.GetKind(*thisMol);
@@ -151,12 +156,17 @@ void EwaldCached::BoxReciprocalSums(uint box, XYZArray const &molCoords) {
     MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(box)
-#endif
+#pragma omp parallel sections default(none) shared(box)
     {
+#pragma omp section
       std::memset(sumRnew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+#pragma omp section
       std::memset(sumInew[box], 0.0, sizeof(double) * imageSizeRef[box]);
     }
+#else
+    std::memset(sumRnew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+    std::memset(sumInew[box], 0.0, sizeof(double) * imageSizeRef[box]);
+#endif
 
     while (thisMol != end) {
       MoleculeKind const &thisKind = mols.GetKind(*thisMol);
@@ -295,14 +305,19 @@ double EwaldCached::SwapDestRecip(const cbmc::TrialMol &newMol, const uint box,
   double energyRecipOld = 0.0;
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) firstprivate(molIndex)
-#endif
+#pragma omp parallel sections default(none) firstprivate(molIndex)
   {
+#pragma omp section
     std::memcpy(cosMolRestore, cosMolRef[molIndex],
                 sizeof(double) * imageTotal);
+#pragma omp section
     std::memcpy(sinMolRestore, sinMolRef[molIndex],
                 sizeof(double) * imageTotal);
   }
+#else
+  std::memcpy(cosMolRestore, cosMolRef[molIndex], sizeof(double) * imageTotal);
+  std::memcpy(sinMolRestore, sinMolRef[molIndex], sizeof(double) * imageTotal);
+#endif
 
   if (box < BOXES_WITH_U_NB) {
     MoleculeKind const &thisKind = newMol.GetKind();

--- a/src/XYZArray.h
+++ b/src/XYZArray.h
@@ -370,13 +370,20 @@ inline void XYZArray::SetRange(const uint start, const uint stop,
 
 inline void XYZArray::ResetRange(const uint val, const uint stop) {
 #ifdef _OPENMP
-#pragma omp parallel default(none) firstprivate(val, stop)
-#endif
+#pragma omp parallel sections default(none) firstprivate(val, stop)
   {
+#pragma omp section
     memset(this->x, val, stop * sizeof(double));
+#pragma omp section
     memset(this->y, val, stop * sizeof(double));
+#pragma omp section
     memset(this->z, val, stop * sizeof(double));
   }
+#else
+  memset(this->x, val, stop * sizeof(double));
+  memset(this->y, val, stop * sizeof(double));
+  memset(this->z, val, stop * sizeof(double));
+#endif
 }
 
 inline void XYZArray::Reset() { ResetRange(0, count); }
@@ -483,14 +490,21 @@ inline void XYZArray::ScaleAll(const double val) { ScaleRange(0, count, val); }
 inline void XYZArray::CopyRange(XYZArray &dest, const uint srcIndex,
                                 const uint destIndex, const uint len) const {
 #ifdef _OPENMP
-#pragma omp parallel default(none) firstprivate(srcIndex, destIndex, len)      \
-    shared(dest)
-#endif
+#pragma omp parallel sections default(none)                                    \
+    firstprivate(srcIndex, destIndex, len) shared(dest)
   {
+#pragma omp section
     memcpy(dest.x + destIndex, x + srcIndex, len * sizeof(double));
+#pragma omp section
     memcpy(dest.y + destIndex, y + srcIndex, len * sizeof(double));
+#pragma omp section
     memcpy(dest.z + destIndex, z + srcIndex, len * sizeof(double));
   }
+#else
+  memcpy(dest.x + destIndex, x + srcIndex, len * sizeof(double));
+  memcpy(dest.y + destIndex, y + srcIndex, len * sizeof(double));
+  memcpy(dest.z + destIndex, z + srcIndex, len * sizeof(double));
+#endif
 }
 
 inline double XYZArray::AdjointMatrix(XYZArray &Inv) {


### PR DESCRIPTION
Due to an incorrect use of OpenMP, constructs like (taken from XYZArray.h):

#pragma omp parallel default(none) firstprivate(val, stop)
  {
    memset(this->x, val, stop * sizeof(double));
    memset(this->y, val, stop * sizeof(double));
    memset(this->z, val, stop * sizeof(double));
  }

results in _every_ thread performing all three of these memset operations. Clearly, these don't need to be done multiple times. The PR uses omp sections to separate the memset calls into distinct omp sections that are each done by only a single thread as intended.

In testing, the revised code shows some modest performance improvement for the MultiParticle move.
