### PR TITLE
Change bad MP moves from error to warning

### DIFF
--- a/src/GPU/TransformParticlesCUDAKernel.cuh
+++ b/src/GPU/TransformParticlesCUDAKernel.cuh
@@ -2,238 +2,96 @@
 GPU OPTIMIZED MONTE CARLO (GOMC) 2.75
 Copyright (C) 2022 GOMC Group
 A copy of the MIT License can be found in License.txt
-along with this program, also can be found at <https://opensource.org/licenses/MIT>.
+along with this program, also can be found at
+<https://opensource.org/licenses/MIT>.
 ********************************************************************************/
 #pragma once
 #ifdef GOMC_CUDA
-#include <vector>
 #include "Random123/philox.h"
+#include <vector>
 typedef r123::Philox4x64 RNG;
 
-#include <cuda.h>
-#include <cuda_runtime.h>
 #include "VariablesCUDA.cuh"
 #include "XYZArray.h"
 #include "math.h"
+#include <cuda.h>
+#include <cuda_runtime.h>
 
-void CallTranslateParticlesGPU(VariablesCUDA *vars,
-                               const std::vector<int8_t> &isMoleculeInvolved,
-                               int box,
-                               double t_max,
-                               double *mForcex,
-                               double *mForcey,
-                               double *mForcez,
-                               std::vector<int> &inForceRange,
-                               ulong step,
-                               unsigned int key,
-                               ulong seed,
-                               const std::vector<int> &particleMol,
-                               int atomCount,
-                               int molCount,
-                               double xAxes,
-                               double yAxes,
-                               double zAxes,
-                               XYZArray &newMolPos,
-                               XYZArray &newCOMs,
-                               double lambdaBETA,
-                               XYZArray &t_k,
-                               XYZArray &molForceRecRef);
+void CallTranslateParticlesGPU(
+    VariablesCUDA *vars, const std::vector<int8_t> &isMoleculeInvolved, int box,
+    double t_max, double *mForcex, double *mForcey, double *mForcez,
+    std::vector<int> &inForceRange, ulong step, unsigned int key, ulong seed,
+    const std::vector<int> &particleMol, int atomCount, int molCount,
+    double xAxes, double yAxes, double zAxes, XYZArray &newMolPos,
+    XYZArray &newCOMs, double lambdaBETA, XYZArray &t_k,
+    XYZArray &molForceRecRef);
 
-void CallRotateParticlesGPU(VariablesCUDA *vars,
-                            const std::vector<int8_t> &isMoleculeInvolved,
-                            int box,
-                            double r_max,
-                            double *mTorquex,
-                            double *mTorquey,
-                            double *mTorquez,
-                            std::vector<int> &inForceRange,
-                            ulong step,
-                            unsigned int key,
-                            ulong seed,
-                            const std::vector<int> &particleMol,
-                            int atomCount,
-                            int molCount,
-                            double xAxes,
-                            double yAxes,
-                            double zAxes,
-                            XYZArray &newMolPos,
-                            XYZArray &newCOMs,
-                            double lambdaBETA,
-                            XYZArray &r_k);
+void CallRotateParticlesGPU(
+    VariablesCUDA *vars, const std::vector<int8_t> &isMoleculeInvolved, int box,
+    double r_max, double *mTorquex, double *mTorquey, double *mTorquez,
+    std::vector<int> &inForceRange, ulong step, unsigned int key, ulong seed,
+    const std::vector<int> &particleMol, int atomCount, int molCount,
+    double xAxes, double yAxes, double zAxes, XYZArray &newMolPos,
+    XYZArray &newCOMs, double lambdaBETA, XYZArray &r_k);
 
-__global__ void TranslateParticlesKernel(unsigned int numberOfMolecules,
-    double t_max,
-    double *molForcex,
-    double *molForcey,
-    double *molForcez,
-    int *inForceRange,
-    ulong step,
-    unsigned int key,
-    ulong seed,
-    double *gpu_x,
-    double *gpu_y,
-    double *gpu_z,
-    int *gpu_particleMol,
-    int atomCount,
-    double xAxes,
-    double yAxes,
-    double zAxes,
-    double *gpu_comx,
-    double *gpu_comy,
-    double *gpu_comz,
-    double *gpu_cell_x,
-    double *gpu_cell_y,
-    double *gpu_cell_z,
-    double *gpu_Invcell_x,
-    double *gpu_Invcell_y,
-    double *gpu_Invcell_z,
-    int *gpu_nonOrth,
-    double lambdaBETA,
-    double *gpu_t_k_x,
-    double *gpu_t_k_y,
-    double *gpu_t_k_z,
-    int8_t *gpu_isMoleculeInvolved,
-    double *gpu_mForceRecx,
-    double *gpu_mForceRecy,
-    double *gpu_mForceRecz);
+__global__ void TranslateParticlesKernel(
+    unsigned int numberOfMolecules, double t_max, double *molForcex,
+    double *molForcey, double *molForcez, int *inForceRange, ulong step,
+    unsigned int key, ulong seed, double *gpu_x, double *gpu_y, double *gpu_z,
+    int *gpu_particleMol, int atomCount, double xAxes, double yAxes,
+    double zAxes, double *gpu_comx, double *gpu_comy, double *gpu_comz,
+    double *gpu_cell_x, double *gpu_cell_y, double *gpu_cell_z,
+    double *gpu_Invcell_x, double *gpu_Invcell_y, double *gpu_Invcell_z,
+    int *gpu_nonOrth, double lambdaBETA, double *gpu_t_k_x, double *gpu_t_k_y,
+    double *gpu_t_k_z, int8_t *gpu_isMoleculeInvolved, double *gpu_mForceRecx,
+    double *gpu_mForceRecy, double *gpu_mForceRecz);
 
-__global__ void RotateParticlesKernel(unsigned int numberOfMolecules,
-                                      double r_max,
-                                      double *molTorquex,
-                                      double *molTorquey,
-                                      double *molTorquez,
-                                      int *inForceRange,
-                                      ulong step,
-                                      unsigned int key,
-                                      ulong seed,
-                                      double *gpu_x,
-                                      double *gpu_y,
-                                      double *gpu_z,
-                                      int *gpu_particleMol,
-                                      int atomCount,
-                                      double xAxes,
-                                      double yAxes,
-                                      double zAxes,
-                                      double *gpu_comx,
-                                      double *gpu_comy,
-                                      double *gpu_comz,
-                                      double *gpu_cell_x,
-                                      double *gpu_cell_y,
-                                      double *gpu_cell_z,
-                                      double *gpu_Invcell_x,
-                                      double *gpu_Invcell_y,
-                                      double *gpu_Invcell_z,
-                                      int *gpu_nonOrth,
-                                      double lambdaBETA,
-                                      double *gpu_r_k_x,
-                                      double *gpu_r_k_y,
-                                      double *gpu_r_k_z,
-                                      int8_t *gpu_isMoleculeInvolved);
+__global__ void RotateParticlesKernel(
+    unsigned int numberOfMolecules, double r_max, double *molTorquex,
+    double *molTorquey, double *molTorquez, int *inForceRange, ulong step,
+    unsigned int key, ulong seed, double *gpu_x, double *gpu_y, double *gpu_z,
+    int *gpu_particleMol, int atomCount, double xAxes, double yAxes,
+    double zAxes, double *gpu_comx, double *gpu_comy, double *gpu_comz,
+    double *gpu_cell_x, double *gpu_cell_y, double *gpu_cell_z,
+    double *gpu_Invcell_x, double *gpu_Invcell_y, double *gpu_Invcell_z,
+    int *gpu_nonOrth, double lambdaBETA, double *gpu_r_k_x, double *gpu_r_k_y,
+    double *gpu_r_k_z, int8_t *gpu_isMoleculeInvolved);
 
 // Brownian Motion multiparticle
 void BrownianMotionRotateParticlesGPU(
-  VariablesCUDA *vars,
-  const std::vector<unsigned int> &moleculeInvolved,
-  XYZArray &mTorque,
-  XYZArray &newMolPos,
-  XYZArray &newCOMs,
-  XYZArray &r_k,
-  const XYZ &boxAxes,
-  const double BETA,
-  const double r_max,
-  ulong step,
-  unsigned int key,
-  ulong seed,
-  const int box,
-  const bool isOrthogonal,
-  int *kill);
-
+    VariablesCUDA *vars, const std::vector<unsigned int> &moleculeInvolved,
+    XYZArray &mTorque, XYZArray &newMolPos, XYZArray &newCOMs, XYZArray &r_k,
+    const XYZ &boxAxes, const double BETA, const double r_max, ulong step,
+    unsigned int key, ulong seed, const int box, const bool isOrthogonal);
 
 void BrownianMotionTranslateParticlesGPU(
-  VariablesCUDA *vars,
-  const std::vector<unsigned int> &moleculeInvolved,
-  XYZArray &mForce,
-  XYZArray &mForceRec,
-  XYZArray &newMolPos,
-  XYZArray &newCOMs,
-  XYZArray &t_k,
-  const XYZ &boxAxes,
-  const double BETA,
-  const double t_max,
-  ulong step,
-  unsigned int key,
-  ulong seed,
-  const int box,
-  const bool isOrthogonal,
-  int *kill);
+    VariablesCUDA *vars, const std::vector<unsigned int> &moleculeInvolved,
+    XYZArray &mForce, XYZArray &mForceRec, XYZArray &newMolPos,
+    XYZArray &newCOMs, XYZArray &t_k, const XYZ &boxAxes, const double BETA,
+    const double t_max, ulong step, unsigned int key, ulong seed, const int box,
+    const bool isOrthogonal);
 
-
-template<const bool isOrthogonal>
+template <const bool isOrthogonal>
 __global__ void BrownianMotionRotateKernel(
-  int *startAtomIdx,
-  double *gpu_x,
-  double *gpu_y,
-  double *gpu_z,
-  double *molTorquex,
-  double *molTorquey,
-  double *molTorquez,
-  double *gpu_comx,
-  double *gpu_comy,
-  double *gpu_comz,
-  double *gpu_r_k_x,
-  double *gpu_r_k_y,
-  double *gpu_r_k_z,
-  int *moleculeInvolved,
-  double *gpu_cell_x,
-  double *gpu_cell_y,
-  double *gpu_cell_z,
-  double *gpu_Invcell_x,
-  double *gpu_Invcell_y,
-  double *gpu_Invcell_z,
-  double3 axis,
-  double3 halfAx,
-  int atomCount,
-  double r_max,
-  ulong step,
-  unsigned int key,
-  ulong seed,
-  double BETA,
-  int *kill);
+    int *startAtomIdx, double *gpu_x, double *gpu_y, double *gpu_z,
+    double *molTorquex, double *molTorquey, double *molTorquez,
+    double *gpu_comx, double *gpu_comy, double *gpu_comz, double *gpu_r_k_x,
+    double *gpu_r_k_y, double *gpu_r_k_z, int *moleculeInvolved,
+    double *gpu_cell_x, double *gpu_cell_y, double *gpu_cell_z,
+    double *gpu_Invcell_x, double *gpu_Invcell_y, double *gpu_Invcell_z,
+    double3 axis, double3 halfAx, int atomCount, double r_max, ulong step,
+    unsigned int key, ulong seed, double BETA);
 
-
-template<const bool isOrthogonal>
+template <const bool isOrthogonal>
 __global__ void BrownianMotionTranslateKernel(
-  int *startAtomIdx,
-  double *gpu_x,
-  double *gpu_y,
-  double *gpu_z,
-  double *molForcex,
-  double *molForcey,
-  double *molForcez,
-  double *molForceRecx,
-  double *molForceRecy,
-  double *molForceRecz,
-  double *gpu_comx,
-  double *gpu_comy,
-  double *gpu_comz,
-  double *gpu_t_k_x,
-  double *gpu_t_k_y,
-  double *gpu_t_k_z,
-  int *moleculeInvolved,
-  double *gpu_cell_x,
-  double *gpu_cell_y,
-  double *gpu_cell_z,
-  double *gpu_Invcell_x,
-  double *gpu_Invcell_y,
-  double *gpu_Invcell_z,
-  double3 axis,
-  double3 halfAx,
-  int atomCount,
-  double t_max,
-  ulong step,
-  unsigned int key,
-  ulong seed,
-  double BETA,
-  int *kill);
+    int *startAtomIdx, double *gpu_x, double *gpu_y, double *gpu_z,
+    double *molForcex, double *molForcey, double *molForcez,
+    double *molForceRecx, double *molForceRecy, double *molForceRecz,
+    double *gpu_comx, double *gpu_comy, double *gpu_comz, double *gpu_t_k_x,
+    double *gpu_t_k_y, double *gpu_t_k_z, int *moleculeInvolved,
+    double *gpu_cell_x, double *gpu_cell_y, double *gpu_cell_z,
+    double *gpu_Invcell_x, double *gpu_Invcell_y, double *gpu_Invcell_z,
+    double3 axis, double3 halfAx, int atomCount, double t_max, ulong step,
+    unsigned int key, ulong seed, double BETA);
 
 #endif

--- a/src/MoveConst.h
+++ b/src/MoveConst.h
@@ -99,9 +99,10 @@ const uint BOX1 = 1;
 // AUTO REJECTION OR ACCEPTANCE FLAGS
 
 namespace fail_state {
-const uint NO_FAIL = 1;
-const uint ROTATE_ON_SINGLE_ATOM = 2;
-const uint NO_MOL_OF_KIND_IN_BOX = 3;
+const uint NO_FAIL = 0;
+const uint ROTATE_ON_SINGLE_ATOM = 1;
+const uint NO_MOL_OF_KIND_IN_BOX = 2;
+const uint INVALID_MP_MOVE_DIST = 3;
 } // namespace fail_state
 
 } // end namespace mv

--- a/src/MoveSettings.cpp
+++ b/src/MoveSettings.cpp
@@ -75,8 +75,16 @@ void MoveSettings::Init(StaticVals const &statV,
 
     // Initialize MultiParticle settings
     for (int b = 0; b < BOX_TOTAL; b++) {
-      mp_r_max[b] = 0.01 * M_PI;
-      mp_t_max[b] = 0.02;
+      // Start with smaller maximum adjustments for Brownian Motion MP
+      // Also need to check for NeMTMC move using Brownian Motion Multiparticle.
+      if (statV.movePerc[mv::MULTIPARTICLE_BM] > TINY_AMOUNT ||
+          (statV.neMTMCVal.enable && statV.neMTMCVal.MPBEnable)) {
+        mp_r_max[b] = 0.0005 * M_PI;
+        mp_t_max[b] = 0.002;
+      } else {
+        mp_r_max[b] = 0.01 * M_PI;
+        mp_t_max[b] = 0.02;
+      }
       for (int m = 0; m < mp::MPTOTALTYPES; m++) {
         mp_tries[b][m] = 0;
         mp_accepted[b][m] = 0;

--- a/src/moves/MultiParticle.h
+++ b/src/moves/MultiParticle.h
@@ -541,7 +541,7 @@ inline void MultiParticle::CalculateTrialDistRot() {
     double *y = r_k.y;
     double *z = r_k.z;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(lambda, r_max, x, y, z)
+#pragma omp parallel for default(none) shared(r_max, x, y, z)
 #endif
     for (uint m = 0; m < moleculeIndex.size(); m++) {
       uint molIndex = moleculeIndex[m];
@@ -563,7 +563,7 @@ inline void MultiParticle::CalculateTrialDistRot() {
     double *y = t_k.y;
     double *z = t_k.z;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(lambda, t_max, x, y, z)
+#pragma omp parallel for default(none) shared(t_max, x, y, z)
 #endif
     for (uint m = 0; m < moleculeIndex.size(); m++) {
       uint molIndex = moleculeIndex[m];

--- a/src/moves/MultiParticle.h
+++ b/src/moves/MultiParticle.h
@@ -337,6 +337,47 @@ inline uint MultiParticle::Transform() {
   // move particles according to force and torque and store them in the new pos
   CalculateTrialDistRot();
 #endif
+
+  // Do error checking and skip if there is an invalid transform amount.
+  for (int m = 0; m < (int)moleculeIndex.size(); m++) {
+    uint molIndex = moleculeIndex[m];
+    XYZ num;
+    if (moveType == mp::MPROTATE) // rotate
+      num = r_k.Get(molIndex);
+    else { // displace
+      num = t_k.Get(molIndex);
+      // check for PBC error and bad initial configuration
+      if (num > boxDimRef.GetHalfAxis(bPick)) {
+        std::cout << "Warning: Trial Displacement exceeds half the box length "
+                     "in Multiparticle move!"
+                  << std::endl;
+        std::cout << "         Trial transformation vector: " << num
+                  << std::endl;
+        std::cout << "         Box Dimensions: " << boxDimRef.GetAxis(bPick)
+                  << std::endl
+                  << std::endl;
+        std::cout << "This might be due to a bad initial configuration, where "
+                     "atoms of the molecules"
+                  << std::endl
+                  << "are too close to each other or overlap. Please "
+                     "equilibrate your system using"
+                  << std::endl
+                  << "rigid body translation or rotation MC moves before using "
+                     "the Multiparticle"
+                  << std::endl
+                  << "move." << std::endl
+                  << std::endl;
+        state = mv::fail_state::NO_MOL_OF_KIND_IN_BOX;
+        break;
+      }
+    }
+    if (!std::isfinite(num.Length())) {
+      std::cout << "Trial Displacement is not a finite number in MultiParticle";
+      std::cout << " move.\nTrial transform: " << num;
+      state = mv::fail_state::NO_MOL_OF_KIND_IN_BOX;
+      break;
+    }
+  }
   GOMC_EVENT_STOP(1, GomcProfileEvent::TRANS_MULTIPARTICLE);
   return state;
 }
@@ -488,19 +529,6 @@ inline XYZ MultiParticle::CalcRandomTransform(bool &forceInRange, XYZ const &lb,
     val.z = log(exp(-1.0 * lbmax.z) + 2.0 * randnums.z * sinh(lbmax.z)) / lb.z;
   }
 
-  // We can possibly bound them
-  if (val.Length() >= boxDimRef.axis.Min(bPick)) {
-    std::cout << "Trial Displacement exceeds half of the box length in "
-                 "MultiParticle move.\n";
-    std::cout << "Trial transform: " << val;
-    exit(EXIT_FAILURE);
-  } else if (!std::isfinite(val.Length())) {
-    std::cout
-        << "Trial Displacement is not a finite number in MultiParticle move.\n";
-    std::cout << "Trial transform: " << val;
-    exit(EXIT_FAILURE);
-  }
-
   return val;
 }
 
@@ -588,28 +616,6 @@ inline void MultiParticle::RotateForceBiased(uint molIndex) {
 
 inline void MultiParticle::TranslateForceBiased(uint molIndex) {
   XYZ shift = t_k.Get(molIndex);
-  if (shift > boxDimRef.GetHalfAxis(bPick)) {
-    std::cout << "Error: Trial Displacement exceeds half the box length in "
-                 "Multiparticle move!"
-              << std::endl;
-    std::cout << "       Trial transformation vector: " << shift << std::endl;
-    std::cout << "       Box Dimensions: " << boxDimRef.GetAxis(bPick)
-              << std::endl
-              << std::endl;
-    std::cout << "This might be due to a bad initial configuration, where "
-                 "atoms of the molecules"
-              << std::endl
-              << "are too close to each other or overlap. Please equilibrate "
-                 "your system using"
-              << std::endl
-              << "rigid body translation or rotation MC moves before using the "
-                 "Multiparticle"
-              << std::endl
-              << "move." << std::endl
-              << std::endl;
-    exit(EXIT_FAILURE);
-  }
-
   XYZ newcom = comCurrRef.Get(molIndex);
   uint stop, start, len;
   molRef.GetRange(start, stop, len, molIndex);


### PR DESCRIPTION
This patch makes bad MP moves produce a warning rather than an error. It also tries to reduce the frequency of bad MP moves with Brownian Motion by starting with a smaller initial move amount.