### PR TITLE
update console output

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -240,7 +240,7 @@ void ConfigSetup::Init(const char *fileName, MultiSim const *const &multisim) {
         in.ffKind.isEXOTIC = false;
         in.ffKind.isMARTINI = false;
         in.ffKind.isCHARMM = true;
-        printf("%-40s %-s \n", "Info: PARAMETER file", "CHARMM format");
+        printf("%-40s %-s \n", "Info: Parameter file", "CHARMM format");
       }
     } else if (CheckString(line[0], "ParaTypeEXOTIC")) {
       if (checkBool(line[1])) {
@@ -248,7 +248,7 @@ void ConfigSetup::Init(const char *fileName, MultiSim const *const &multisim) {
         in.ffKind.isCHARMM = false;
         in.ffKind.isMARTINI = false;
         in.ffKind.isEXOTIC = true;
-        printf("%-40s %-s \n", "Info: PARAMETER file", "MIE format");
+        printf("%-40s %-s \n", "Info: Parameter file", "MIE format");
       }
     } else if (CheckString(line[0], "ParaTypeMIE")) {
       if (checkBool(line[1])) {
@@ -256,7 +256,7 @@ void ConfigSetup::Init(const char *fileName, MultiSim const *const &multisim) {
         in.ffKind.isCHARMM = false;
         in.ffKind.isMARTINI = false;
         in.ffKind.isEXOTIC = true;
-        printf("%-40s %-s \n", "Info: PARAMETER file", "MIE format");
+        printf("%-40s %-s \n", "Info: Parameter file", "MIE format");
       }
     } else if (CheckString(line[0], "ParaTypeMARTINI")) {
       if (checkBool(line[1])) {
@@ -264,7 +264,7 @@ void ConfigSetup::Init(const char *fileName, MultiSim const *const &multisim) {
         in.ffKind.isEXOTIC = false;
         in.ffKind.isMARTINI = true;
         in.ffKind.isCHARMM = true;
-        printf("%-40s %-s \n", "Info: PARAMETER file",
+        printf("%-40s %-s \n", "Info: Parameter file",
                "MARTINI using CHARMM format");
       }
     } else if (CheckString(line[0], "Parameters")) {
@@ -1883,7 +1883,7 @@ void ConfigSetup::verifyInputs(void) {
   }
   if (((sys.ff.VDW_KIND == sys.ff.VDW_STD_KIND) ||
        (sys.ff.VDW_KIND == sys.ff.VDW_EXP6_KIND)) &&
-      (!sys.ff.doImpulsePressureCorr && !sys.ff.doTailCorr)) {
+      (sys.ff.doImpulsePressureCorr && sys.ff.doTailCorr)) {
     std::cout << "ERROR: Impulse Pressure Correction cannot be "
               << "used with LJ long-range corrections." << std::endl;
     exit(EXIT_FAILURE);

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -22,7 +22,7 @@ along with this program, also can be found at
 const uint FFSetup::CHARMM_ALIAS_IDX = 0;
 const uint FFSetup::EXOTIC_ALIAS_IDX = 1;
 const std::string FFSetup::paramFileAlias[] = {"CHARMM-Style parameter file",
-                                               "EXOTIC-Style parameter file"};
+                                               "Mie-Style parameter file"};
 const double ff_setup::KCAL_PER_MOL_TO_K = 503.21959899;
 const double ff_setup::RIJ_OVER_2_TO_SIG = 1.7817974362807;
 const double ff_setup::RIJ_TO_SIG = 0.890898718;
@@ -106,10 +106,10 @@ void FFSetup::Init(const std::vector<config_setup::FileName> &fileName,
         if (isCHARMM) {
           if (hasEnding(currSectName, "MIE")) {
             std::cout << "Error: CHARMM-Style parameter is set but "
-                         "EXOTIC-Style parameter header "
+                         "Mie-Style parameter header "
                       << currSectName
                       << " was found.\n"
-                         "       Either set EXOTIC-Style in config file or "
+                         "       Either set Mie-Style in config file or "
                          "change the keyword\n"
                          "       "
                       << currSectName << " to "
@@ -122,7 +122,7 @@ void FFSetup::Init(const std::vector<config_setup::FileName> &fileName,
           std::regex nbfix("NBFIX");
           if (std::regex_match(currSectName, nbonded) ||
               std::regex_match(currSectName, nbfix)) {
-            std::cout << "Error: EXOTIC-Style parameter is set but "
+            std::cout << "Error: Mie-Style parameter is set but "
                          "CHARMM-Style parameter header "
                       << currSectName
                       << " was found.\n"
@@ -146,14 +146,14 @@ void FFSetup::Init(const std::vector<config_setup::FileName> &fileName,
   // check if we read nonbonded parameter
   if (mie.sigma.size() == 0) {
     if (isCHARMM) {
-      std::cout << "Error: CHARMM-Style parameter is set but EXOTIC-Style "
+      std::cout << "Error: CHARMM-Style parameter is set but Mie-Style "
                    "parameter file was found.\n"
-                   "       Either set EXOTIC-Style in config file or change "
+                   "       Either set Mie-Style in config file or change "
                    "the keyword\n"
                    "       \"NONBONDED_MIE\" to \"NONBONDED\" in the parameter "
                    "files.\n";
     } else {
-      std::cout << "Error: EXOTIC-Style parameter is set but CHARMM-Style "
+      std::cout << "Error: Mie-Style parameter is set but CHARMM-Style "
                    "parameter file was found.\n"
                    "       Either set CHARMM-Style in config file or change "
                    "the keyword\n"


### PR DESCRIPTION
Updating console output replacing the word "EXOTIC" with "Mie" when referring to the parameter file loaded.  Also includes a fix for the IPC and LRC checking in ConfigSetup.cpp  Previously, if LRC and IPC == false the simulation would flag that as an error, but this isn't a problem.  Meanwhile, it didn't check for the condition we want to avoid (both IPC and LRC true). 