### PR TITLE
Free the GPU variables allocated for the Exp6 Forcefield

### DIFF
--- a/src/FFExp6.h
+++ b/src/FFExp6.h
@@ -33,6 +33,9 @@ public:
       : FFParticle(ff), expConst(NULL), expConst_1_4(NULL), rMin(NULL),
         rMin_1_4(NULL), rMaxSq(NULL), rMaxSq_1_4(NULL) {}
   virtual ~FF_EXP6() {
+#ifdef GOMC_CUDA
+    DestroyExp6CUDAVars(ff.particles->getCUDAVars());
+#endif
     delete[] expConst;
     delete[] expConst_1_4;
     delete[] rMin;
@@ -141,7 +144,7 @@ inline void FF_EXP6::Init(ff_setup::Particle const &mie,
     }
   }
 #ifdef GOMC_CUDA
-  InitExp6Variables(varCUDA, rMin, expConst, rMaxSq, size);
+  InitExp6VariablesCUDA(varCUDA, rMin, expConst, rMaxSq, size);
 #endif
 }
 

--- a/src/GPU/ConstantDefinitionsCUDAKernel.cu
+++ b/src/GPU/ConstantDefinitionsCUDAKernel.cu
@@ -141,8 +141,8 @@ void InitCoordinatesCUDA(VariablesCUDA *vars, uint atomNumber,
   checkLastErrorCUDA(__FILE__, __LINE__);
 }
 
-void InitExp6Variables(VariablesCUDA *vars, double *rMin, double *expConst,
-                       double *rMaxSq, uint size) {
+void InitExp6VariablesCUDA(VariablesCUDA *vars, double *rMin, double *expConst,
+                           double *rMaxSq, uint size) {
   CUMALLOC((void **)&vars->gpu_rMin, size * sizeof(double));
   CUMALLOC((void **)&vars->gpu_rMaxSq, size * sizeof(double));
   CUMALLOC((void **)&vars->gpu_expConst, size * sizeof(double));
@@ -307,6 +307,12 @@ void DestroyEwaldCUDAVars(VariablesCUDA *vars) {
   delete[] vars->gpu_prefactRef;
   delete[] vars->gpu_hsqr;
   delete[] vars->gpu_hsqrRef;
+}
+
+void DestroyExp6CUDAVars(VariablesCUDA *vars) {
+  CUFREE(vars->gpu_rMin);
+  CUFREE(vars->gpu_rMaxSq);
+  CUFREE(vars->gpu_expConst);
 }
 
 void DestroyCUDAVars(VariablesCUDA *vars) {

--- a/src/GPU/ConstantDefinitionsCUDAKernel.cuh
+++ b/src/GPU/ConstantDefinitionsCUDAKernel.cuh
@@ -31,6 +31,8 @@ void InitGPUForceField(VariablesCUDA &vars, double const *sigmaSq,
 void InitCoordinatesCUDA(VariablesCUDA *vars, uint atomNumber,
                          uint maxAtomsInMol, uint maxMolNumber);
 void InitEwaldVariablesCUDA(VariablesCUDA *vars, uint imageTotal);
+void InitExp6VariablesCUDA(VariablesCUDA *vars, double *rMin, double *expConst,
+                           double *rMaxSq, uint size);
 void CopyCurrentToRefCUDA(VariablesCUDA *vars, uint box, uint imageTotal);
 void CopyRefToNewCUDA(VariablesCUDA *vars, uint box, uint imageTotal);
 void UpdateRecipVecCUDA(VariablesCUDA *vars, uint box);
@@ -41,9 +43,8 @@ void UpdateInvCellBasisCUDA(VariablesCUDA *vars, uint box,
                             double *invCellBasis_x, double *invCellBasis_y,
                             double *invCellBasis_z);
 void DestroyEwaldCUDAVars(VariablesCUDA *vars);
+void DestroyExp6CUDAVars(VariablesCUDA *vars);
 void DestroyCUDAVars(VariablesCUDA *vars);
-void InitExp6Variables(VariablesCUDA *vars, double *rMin, double *expConst,
-                       double *rMaxSq, uint size);
 
 #endif /*GOMC_CUDA*/
 #endif /*CONSTANT_DEFINITIONS_CUDA_KERNEL*/


### PR DESCRIPTION
This PR resolved issue #512. The code needed to have a function to deallocate the variables.

I also changed the names for these two GPU functions (Init and Destroy) for the Exp6 variables to be consistent with similar function names. And I moved some function definitions in the header file to organize things better.