### PR TITLE
Fix issue #514: Output correct block averages first time after restart

### DIFF
--- a/src/BlockOutput.h
+++ b/src/BlockOutput.h
@@ -110,21 +110,15 @@ private:
   void InitVals(config_setup::EventSettings const &event) {
     stepsPerOut = event.frequency;
     invSteps = 1.0 / stepsPerOut;
-    if (startStep != 0) {
+    firstInvSteps = invSteps;
+    //Handle the case where we are restarting from a checkpoint and the first
+    //interval is smaller than expected because we create a checkpoint more
+    //often than the Block output frequency.
+    if (startStep != 0 && (startStep % stepsPerOut) != 0) {
       ulong diff;
-      if (stepsPerOut >= startStep) {
-        diff = stepsPerOut - startStep;
-      } else {
-        diff = startStep - stepsPerOut;
-      }
-      firstInvSteps = 1.0 / diff;
-    } else {
-      firstInvSteps = invSteps;
+      diff = stepsPerOut - (startStep % stepsPerOut);
+      firstInvSteps = 1.0/diff;
     }
-    // We only subtract the firstInvSteps on
-    // the first print with startStep != 0
-    // invSteps - firstInvSteps = 1/(stepsPerOut-startStep)
-    // After the first print
     enableOut = event.enable;
   }
   void AllocBlocks(void);


### PR DESCRIPTION
The code for computing the number of steps from the checkpoint to the first output of block averages was wrong when we were restarting.

The correct values were being computed by the system, but we output the wrong block averages because the code calculated the number of steps incorrectly, so had the wrong denominator.

The patch has been tested against the example provided in issue #514 and is now producing the expected output.