### PR TITLE
Improve FFExp6 patch to work with GTest

### DIFF
--- a/src/FFExp6.h
+++ b/src/FFExp6.h
@@ -34,7 +34,7 @@ public:
         rMin_1_4(NULL), rMaxSq(NULL), rMaxSq_1_4(NULL) {}
   virtual ~FF_EXP6() {
 #ifdef GOMC_CUDA
-    DestroyExp6CUDAVars(ff.particles->getCUDAVars());
+    DestroyExp6CUDAVars(getCUDAVars());
 #endif
     delete[] expConst;
     delete[] expConst_1_4;
@@ -144,7 +144,7 @@ inline void FF_EXP6::Init(ff_setup::Particle const &mie,
     }
   }
 #ifdef GOMC_CUDA
-  InitExp6VariablesCUDA(varCUDA, rMin, expConst, rMaxSq, size);
+  InitExp6VariablesCUDA(getCUDAVars(), rMin, expConst, rMaxSq, size);
 #endif
 }
 


### PR DESCRIPTION
The patch for issue #512 did not compile when building to use gtest. It's not clear why it compiles sometimes and doesn't other times, but this patch is better, as it works for all builds. And makes better use of the OOP features of the code, like using getCUDAVars() to return the appropriate data member instead of accessing the data member directly.