### PR TITLE
Allows GEMC simulations to control which boxes run MP moves

### DIFF
--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -82,6 +82,8 @@ ConfigSetup::ConfigSetup(void) {
   sys.moves.rotate = DBL_MAX;
   sys.moves.intraSwap = DBL_MAX;
   sys.moves.multiParticleEnabled = false;
+  sys.moves.multiParticleLiquid = true;
+  sys.moves.multiParticleGas = false;
   sys.moves.multiParticle = DBL_MAX;
   sys.moves.multiParticleBrownian = DBL_MAX;
   sys.moves.regrowth = DBL_MAX;
@@ -793,6 +795,14 @@ void ConfigSetup::Init(const char *fileName, MultiSim const *const &multisim) {
       }
       printf("%-40s %-4.4f \n", "Info: Multi-Particle move frequency",
              sys.moves.multiParticle);
+    } else if (CheckString(line[0], "MultiParticleLiquid")) {
+      sys.moves.multiParticleLiquid = checkBool(line[1]);
+      printf("%-40s %-4.4f \n", "Info: Multi-Particle liquid box move",
+             sys.moves.multiParticleLiquid ? "Active" : "Inactive");
+    } else if (CheckString(line[0], "MultiParticleGas")) {
+      sys.moves.multiParticleGas = checkBool(line[1]);
+      printf("%-40s %-4.4f \n", "Info: Multi-Particle gas box move",
+             sys.moves.multiParticleGas ? "Active" : "Inactive");
     } else if (CheckString(line[0], "MultiParticleBrownianFreq")) {
       sys.moves.multiParticleBrownian = stringtod(line[1]);
       if (sys.moves.multiParticleBrownian > 0.0) {
@@ -1960,6 +1970,13 @@ void ConfigSetup::verifyInputs(void) {
       printf("%-40s %-4.4f \n", "ADV USER: Displacement move frequency",
              sys.moves.displace);
     }
+  }
+
+  if (sys.moves.multiParticleEnabled && !sys.moves.multiParticleLiquid &&
+      !sys.moves.multiParticleGas) {
+    std::cout << "ERROR: Multi-Particle moves require either liquid or gas "
+              << "box active!" << std::endl;
+    exit(EXIT_FAILURE);
   }
 #if ENSEMBLE == NPT
   if (sys.moves.volume == DBL_MAX) {

--- a/src/ConfigSetup.cpp
+++ b/src/ConfigSetup.cpp
@@ -797,11 +797,11 @@ void ConfigSetup::Init(const char *fileName, MultiSim const *const &multisim) {
              sys.moves.multiParticle);
     } else if (CheckString(line[0], "MultiParticleLiquid")) {
       sys.moves.multiParticleLiquid = checkBool(line[1]);
-      printf("%-40s %-4.4f \n", "Info: Multi-Particle liquid box move",
+      printf("%-40s %-s \n", "Info: Multi-Particle liquid box move",
              sys.moves.multiParticleLiquid ? "Active" : "Inactive");
     } else if (CheckString(line[0], "MultiParticleGas")) {
       sys.moves.multiParticleGas = checkBool(line[1]);
-      printf("%-40s %-4.4f \n", "Info: Multi-Particle gas box move",
+      printf("%-40s %-s \n", "Info: Multi-Particle gas box move",
              sys.moves.multiParticleGas ? "Active" : "Inactive");
     } else if (CheckString(line[0], "MultiParticleBrownianFreq")) {
       sys.moves.multiParticleBrownian = stringtod(line[1]);

--- a/src/ConfigSetup.h
+++ b/src/ConfigSetup.h
@@ -5,8 +5,8 @@ A copy of the MIT License can be found in License.txt
 along with this program, also can be found at
 <https://opensource.org/licenses/MIT>.
 ********************************************************************************/
-#ifndef CONFIGSETUP_H
-#define CONFIGSETUP_H
+#ifndef CONFIG_SETUP_H
+#define CONFIG_SETUP_H
 
 #include <iostream> //for cerr, cout;
 #include <map>      //for function handle storage.
@@ -173,6 +173,7 @@ struct MovePercents {
   double displace, rotate, intraSwap, intraMemc, regrowth, crankShaft,
       multiParticle, multiParticleBrownian, intraTargetedSwap;
   bool multiParticleEnabled; // for both multiparticle and multiparticleBrownian
+  bool multiParticleLiquid, multiParticleGas; // GEMC: set boxes for MP moves
 #ifdef VARIABLE_VOLUME
   double volume;
 #endif
@@ -918,4 +919,4 @@ private:
   InputFileReader reader;
 };
 
-#endif
+#endif /*CONFIG_SETUP_H*/

--- a/src/StaticVals.cpp
+++ b/src/StaticVals.cpp
@@ -137,6 +137,8 @@ StaticVals::StaticVals(Setup &set)
 
 {
   multiParticleEnabled = set.config.sys.moves.multiParticleEnabled;
+  multiParticleLiquid = set.config.sys.moves.multiParticleLiquid;
+  multiParticleGas = set.config.sys.moves.multiParticleGas;
   isOrthogonal = true;
   if (set.config.in.restart.enable) {
     IsBoxOrthogonal(set.pdb.cryst.cellAngle);

--- a/src/StaticVals.h
+++ b/src/StaticVals.h
@@ -39,6 +39,7 @@ public:
 #endif
   bool isOrthogonal;
   bool multiParticleEnabled;
+  bool multiParticleLiquid, multiParticleGas;
 
   Forcefield forcefield;
   SimEventFrequency simEventFreq;


### PR DESCRIPTION
This patch resolves issue #520 by adding two boolean flags that can be used in the config file. The flags are:

MultipleParticleLiquid
MultipleParticleGas

The default settings are true for the liquid box and false for the gas box. The boxes are labeled at runtime, before running each move, based on the density of each box.

This applies only to GEMC simulations. The idea is that a MP move typically makes sense to be run in the liquid box because of the higher box density, however, any combination of flags is valid, except for setting both to false, since that would prevent the MP move from working.

This patch works for both force-based MP and Brownian-motion MP moves. It does not change the behavior of the NeMT move, which picks the box via a different process.