### PR TITLE
Optimize operator overloading for XYZ objects

### DIFF
--- a/lib/BasicTypes.h
+++ b/lib/BasicTypes.h
@@ -97,17 +97,18 @@ inline void record_debug(uint *x, uint len, std::string filename,
 
 //******************************************************************************
 
-typedef unsigned int uint;
-typedef unsigned long int ulong;
-
-#define UNUSED(x) (void)(x)
-
-// single XYZ for use as a temporary and return type
-struct XYZ {
-  double x, y, z;
-
+// single XYZ coordinate for use as a temporary and return type
+class XYZ {
+public:
   XYZ() : x(0.0), y(0.0), z(0.0) {}
   XYZ(double xVal, double yVal, double zVal) : x(xVal), y(yVal), z(zVal) {}
+
+  friend inline std::ostream &operator<<(std::ostream &stream, const XYZ &p);
+  
+  inline double getX() const { return x; }
+  inline double getY() const { return y; }
+  inline double getZ() const { return z; }
+
   void Reset() { x = y = z = 0.0; }
   XYZ &operator=(XYZ const &rhs) {
     x = rhs.x;
@@ -115,26 +116,19 @@ struct XYZ {
     z = rhs.z;
     return *this;
   }
-  bool operator==(XYZ const &rhs) {
-    if (x == rhs.x && y == rhs.y && z == rhs.z)
-      return true;
-    return false;
+  inline bool operator==(XYZ const &rhs) const {
+    return (x == rhs.x && y == rhs.y && z == rhs.z);
   }
-  bool operator!=(XYZ const &rhs) {
-    if (x != rhs.x || y != rhs.y || z != rhs.z)
-      return true;
-    return false;
+  inline bool operator!=(XYZ const &rhs) const {
+    return (x != rhs.x || y != rhs.y || z != rhs.z);
   }
-  bool operator<(XYZ const &rhs) {
-    if (x < rhs.x && y < rhs.y && z < rhs.z)
-      return true;
-    return false;
+  inline bool operator<(XYZ const &rhs) const {
+    return (x < rhs.x && y < rhs.y && z < rhs.z);
   }
-  bool operator>(XYZ const &rhs) {
-    if (x > rhs.x || y > rhs.y || z > rhs.z)
-      return true;
-    return false;
+  inline bool operator>(XYZ const &rhs) const {
+    return (x > rhs.x || y > rhs.y || z > rhs.z);
   }
+
   XYZ &operator+=(XYZ const &rhs) {
     x += rhs.x;
     y += rhs.y;
@@ -167,14 +161,14 @@ struct XYZ {
     return *this;
   }
 
-  XYZ operator+(XYZ const &rhs) const { return XYZ(*this) += rhs; }
-  XYZ operator-(XYZ const &rhs) const { return XYZ(*this) -= rhs; }
-  XYZ operator*(XYZ const &rhs) const { return XYZ(*this) *= rhs; }
-  XYZ operator/(XYZ const &rhs) const { return XYZ(*this) /= rhs; }
+  XYZ operator+(XYZ const &rhs) const { return XYZ(x+rhs.x, y+rhs.y, z+rhs.z); }
+  XYZ operator-(XYZ const &rhs) const { return XYZ(x-rhs.x, y-rhs.y, z-rhs.z); }
+  XYZ operator*(XYZ const &rhs) const { return XYZ(x*rhs.x, y*rhs.y, z*rhs.z); }
+  XYZ operator/(XYZ const &rhs) const { return XYZ(x/rhs.x, y/rhs.y, z/rhs.z); }
 
-  XYZ operator*(const double a) const { return XYZ(*this) *= a; }
+  XYZ operator*(const double a) const { return XYZ(x*a, y*a, z*a); }
 
-  XYZ operator-() const { return XYZ(*this) * -1.0; }
+  XYZ operator-() const { return XYZ(-x, -y, -z); }
 
   void Inverse() {
     x = 1.0 / x;
@@ -182,11 +176,11 @@ struct XYZ {
     z = 1.0 / z;
   }
 
-  double Length() const { return sqrt(LengthSq()); }
   double LengthSq() const { return x * x + y * y + z * z; }
+  double Length() const { return sqrt(LengthSq()); }
 
   XYZ &Normalize() {
-    *this *= (1 / Length());
+    *this *= (1.0 / Length());
     return *this;
   }
 
@@ -207,6 +201,9 @@ struct XYZ {
       m = z;
     return m;
   }
+
+public:
+  double x, y, z;
 };
 
 inline std::ostream &operator<<(std::ostream &stream, const XYZ &p) {

--- a/lib/BasicTypes.h
+++ b/lib/BasicTypes.h
@@ -177,7 +177,7 @@ public:
   }
 
   double LengthSq() const { return x * x + y * y + z * z; }
-  double Length() const { return sqrt(LengthSq()); }
+  double Length() const { return std::sqrt(LengthSq()); }
 
   XYZ &Normalize() {
     *this *= (1.0 / Length());


### PR DESCRIPTION
This pull request creates a more efficient implementation of many of the overloaded operators for the XYZ class. It should run faster and is more readable. It is a cleaner C++ implementation of the XYZ class.

It also changes the XYZ struct to an XYZ class, although making the data members private is complicated by the fact that many other classes access these variables directly. So, they are currently kept as public members.

Also, removed some unused types and UNUSED, which isn't used in the code.