### PR TITLE
Reduce max volume adjustment to avoid negative box dimensions

### DIFF
--- a/src/BoxDimensions.cpp
+++ b/src/BoxDimensions.cpp
@@ -110,9 +110,13 @@ uint BoxDimensions::ShiftVolume(BoxDimensions &newDim, XYZ &scale, const uint b,
   // automatically reject to prevent errors.
   if ((newDim.halfAx.x[b] < rCut[b] || newDim.halfAx.y[b] < rCut[b] ||
        newDim.halfAx.z[b] < rCut[b] || newVolume < minVol[b])) {
-    std::cout << "WARNING!!! box shrunk below 2*Rcut! Auto-rejecting!\n";
-    std::cout << "AxisDimensions: " << newDim.GetAxis(b) << std::endl;
-    std::cout << "Exiting!\n";
+    std::cout << "WARNING!!! Box " << b
+              << " shrunk below 2*Rcut! Auto-rejecting!" << std::endl;
+    std::cout << "Volume was reduced from " << volume[b] << " to " << newVolume
+              << std::endl;
+    std::cout << "Old Axis Dimensions: " << axis.Get(b) << std::endl;
+    std::cout << "New Axis Dimensions: " << newDim.GetAxis(b) << std::endl;
+    std::cout << "Exiting!" << std::endl;
     exit(EXIT_FAILURE);
   }
   scale = newDim.axis.Get(b) / axis.Get(b);

--- a/src/BoxDimensionsNonOrth.cpp
+++ b/src/BoxDimensionsNonOrth.cpp
@@ -178,9 +178,13 @@ uint BoxDimensionsNonOrth::ShiftVolume(BoxDimensionsNonOrth &newDim, XYZ &scale,
   // automatically reject to prevent errors.
   if ((newDim.halfAx.x[b] < rCut[b] || newDim.halfAx.y[b] < rCut[b] ||
        newDim.halfAx.z[b] < rCut[b] || newVolume < minVol[b])) {
-    std::cout << "WARNING!!! box shrunk below 2*Rcut! Auto-rejecting!\n";
-    std::cout << "AxisDimensions: " << newDim.GetAxis(b) << std::endl;
-    std::cout << "Exiting!\n";
+    std::cout << "WARNING!!! Box " << b
+              << " shrunk below 2*Rcut! Auto-rejecting!" << std::endl;
+    std::cout << "Volume was reduced from " << volume[b] << " to " << newVolume
+              << std::endl;
+    std::cout << "Old Axis Dimensions: " << axis.Get(b) << std::endl;
+    std::cout << "New Axis Dimensions: " << newDim.GetAxis(b) << std::endl;
+    std::cout << "Exiting!" << std::endl;
     exit(EXIT_FAILURE);
   }
   scale = newDim.axis.Get(b) / axis.Get(b);

--- a/src/MoveSettings.cpp
+++ b/src/MoveSettings.cpp
@@ -254,8 +254,9 @@ void MoveSettings::Adjust(const uint box, const uint move, const uint kind) {
         scale[box][move][kind] *= 0.5;
       }
     }
-    // Warning: This will lead to have acceptance > 50%
-    double maxVolExchange = boxDimRef.volume[box] - boxDimRef.minVol[box];
+    // Warning: This could lead to an acceptance of > 50%
+    double maxVolExchange =
+        boxDimRef.volume[box] * 0.34 - boxDimRef.minVol[box];
     num::Bound<double>(scale[box][move][kind], 0.001, maxVolExchange - 0.001);
   }
 #endif


### PR DESCRIPTION
This pull request resolves issue #525 by limiting the maximum volume move to about 1/3rd of the current volume of the box.

It also enhances the error message that is produced if this error recurs, so that it is easier to determine the cause of the problem.