### PR TITLE
Fix calls to Mersenne Twister for CBMC functions

### DIFF
--- a/src/cbmc/DCFreeCycle.cpp
+++ b/src/cbmc/DCFreeCycle.cpp
@@ -139,9 +139,13 @@ void DCFreeCycle::BuildNew(TrialMol &newMol, uint molIndex) {
   positions[hed.NumBond()].Set(0, newMol.RawRectCoords(anchorBond, 0, 0));
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 0;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));
@@ -217,9 +221,13 @@ void DCFreeCycle::BuildOld(TrialMol &oldMol, uint molIndex) {
   positions[hed.NumBond()].Add(0, -center);
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 1;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));

--- a/src/cbmc/DCFreeCycleSeed.cpp
+++ b/src/cbmc/DCFreeCycleSeed.cpp
@@ -138,9 +138,13 @@ void DCFreeCycleSeed::BuildNew(TrialMol &newMol, uint molIndex) {
   positions[hed.NumBond()].Set(0, newMol.RawRectCoords(anchorBond, 0, 0));
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 0;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));
@@ -216,9 +220,13 @@ void DCFreeCycleSeed::BuildOld(TrialMol &oldMol, uint molIndex) {
   positions[hed.NumBond()].Add(0, -center);
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 1;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));

--- a/src/cbmc/DCFreeHedron.cpp
+++ b/src/cbmc/DCFreeHedron.cpp
@@ -118,9 +118,13 @@ void DCFreeHedron::BuildNew(TrialMol &newMol, uint molIndex) {
   positions[hed.NumBond()].Set(0, newMol.RawRectCoords(anchorBond, 0, 0));
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 0;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));
@@ -196,9 +200,13 @@ void DCFreeHedron::BuildOld(TrialMol &oldMol, uint molIndex) {
   positions[hed.NumBond()].Add(0, -center);
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 1;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));

--- a/src/cbmc/DCFreeHedronSeed.cpp
+++ b/src/cbmc/DCFreeHedronSeed.cpp
@@ -117,9 +117,13 @@ void DCFreeHedronSeed::BuildNew(TrialMol &newMol, uint molIndex) {
   positions[hed.NumBond()].Set(0, newMol.RawRectCoords(anchorBond, 0, 0));
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 0;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));
@@ -195,9 +199,13 @@ void DCFreeHedronSeed::BuildOld(TrialMol &oldMol, uint molIndex) {
   positions[hed.NumBond()].Add(0, -center);
 
   // counting backward to preserve prototype
+  double u1, u2, u3;
   for (uint lj = nLJTrials; lj-- > 1;) {
     // convert chosen torsion to 3D positions
-    RotationMatrix spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+    u1 = prng();
+    u2 = prng();
+    u3 = prng();
+    RotationMatrix spin = RotationMatrix::UniformRandom(u1, u2, u3);
     for (uint b = 0; b < hed.NumBond() + 1; ++b) {
       // find positions
       positions[b].Set(lj, spin.Apply(positions[b][0]));

--- a/src/cbmc/DCRotateCOM.cpp
+++ b/src/cbmc/DCRotateCOM.cpp
@@ -182,7 +182,11 @@ void DCRotateCOM::BuildNew(TrialMol &newMol, uint molIndex) {
         RandRotateZ();
       } else {
         // convert chosen torsion to 3D positions
-        spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+        double u1, u2, u3;
+        u1 = prng();
+        u2 = prng();
+        u3 = prng();
+        spin = RotationMatrix::UniformRandom(u1, u2, u3);
       }
 
       for (uint a = 0; a < atomNumber; ++a) {
@@ -287,7 +291,11 @@ void DCRotateCOM::BuildOld(TrialMol &oldMol, uint molIndex) {
         RandRotateZ();
       } else {
         // convert chosen torsion to 3D positions
-        spin = RotationMatrix::UniformRandom(prng(), prng(), prng());
+        double u1, u2, u3;
+        u1 = prng();
+        u2 = prng();
+        u3 = prng();
+        spin = RotationMatrix::UniformRandom(u1, u2, u3);
       }
 
       for (uint a = 0; a < atomNumber; ++a) {


### PR DESCRIPTION
The previous patch for issue #498 didn't address the problem for functions that were in the CBMC branch, so the same problem of inconsistent results was recurring for simulations that ran on gcc versus icc.

This patch updates those files. Also did a search and there don't seem to be any other function calls that might have this same problem, so hopefully this patch resolves the issue completely.