### PR TITLE
Detect and remove duplicate dihedrals with the same periodicity

### DIFF
--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -380,7 +380,8 @@ void Dihedral::Read(Reader &param, std::string const &firstVar) {
   if (index == 0) {
     // set phase shift for n=0 to 90 degree
     // We will have C0 = Kchi (1 + cos(0 * phi + 90)) = Kchi
-    //this avoids double counting the C0 (constant offset) term, which is used force fields like TraPPE
+    // this avoids double counting the C0 (constant offset) term, which is used
+    // in force fields like TraPPE
     def = 90.00;
   }
   Add(merged, coeff, index, def);

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -411,8 +411,8 @@ void Dihedral::Add(const std::string &fileName, const std::string &merged,
         exit(EXIT_FAILURE);
       } else {
         std::cout << "Warning: Ignoring duplicate periodicity of " << index
-                  << " for dihedral " << merged << " in "
-                  << fileName.c_str() << ". Using first entry.\n";
+                  << " for dihedral " << merged << " in " << fileName.c_str()
+                  << ".\n";
         return;
       }
     }

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -187,9 +187,10 @@ std::string FFBase::ReadKind(Reader &param, std::string const &firstKindName) {
     merged += tmp;
   }
   // Skip duplicates unless we allow multiple entries, such as for dihedrals
-  if (!multi && std::find(name.begin(), name.end(), merged) != name.end())
-    std::cout << "Warning: Ignoring duplicate entry of " << merged
-              << ". Using first entry!\n";
+  if (!multi && std::find(name.begin(), name.end(), merged) != name.end()) {
+    std::cout << "Warning: Ignoring duplicate entry for " << merged << " in "
+              << param.getFileName().c_str() << ". Using first entry!\n";
+  }
   // Might insert duplicates but they will be ignored during execution
   if (!multi || std::find(name.begin(), name.end(), merged) == name.end())
     name.push_back(merged);
@@ -389,11 +390,11 @@ void Dihedral::Read(Reader &param, std::string const &firstVar) {
     // in force fields like TraPPE
     def = 90.00;
   }
-  Add(merged, coeff, index, def);
+  Add(param.getFileName(), merged, coeff, index, def);
   last = merged;
 }
-void Dihedral::Add(std::string const &merged, const double coeff,
-                   const uint index, const double def) {
+void Dihedral::Add(const std::string &fileName, const std::string &merged,
+                   const double coeff, const uint index, const double def) {
   // Check for (and skip) duplicate periodicities for the same dihedral
   // Generate an error and terminate if the duplicate dihedrals have different
   // parameters
@@ -405,12 +406,13 @@ void Dihedral::Add(std::string const &merged, const double coeff,
       if (std::fabs(*Kchi_it - EnConvIfCHARMM(coeff)) > EPSILON ||
           std::fabs(*delta_it - geom::DegToRad(def)) > EPSILON) {
         std::cout << "Error: Inconsistent dihedral parameters were found in "
-                  << "parameter file for dihedral " << merged << " with "
-                  << "periodicity " << index << "!\n";
+                  << fileName.c_str() << " for dihedral " << merged
+                  << " with periodicity " << index << "!\n";
         exit(EXIT_FAILURE);
       } else {
         std::cout << "Warning: Ignoring duplicate periodicity of " << index
-                  << " for dihedral " << merged << ". Using first entry!\n";
+                  << " for dihedral " << merged << " in "
+                  << fileName.c_str() << ". Using first entry!\n";
         return;
       }
     }

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -189,7 +189,7 @@ std::string FFBase::ReadKind(Reader &param, std::string const &firstKindName) {
   // Skip duplicates unless we allow multiple entries, such as for dihedrals
   if (!multi && std::find(name.begin(), name.end(), merged) != name.end()) {
     std::cout << "Warning: Ignoring duplicate entry for " << merged << " in "
-              << param.getFileName().c_str() << ". Using first entry!\n";
+              << param.getFileName().c_str() << ". Using first entry.\n";
   }
   // Might insert duplicates but they will be ignored during execution
   if (!multi || std::find(name.begin(), name.end(), merged) == name.end())
@@ -412,7 +412,7 @@ void Dihedral::Add(const std::string &fileName, const std::string &merged,
       } else {
         std::cout << "Warning: Ignoring duplicate periodicity of " << index
                   << " for dihedral " << merged << " in "
-                  << fileName.c_str() << ". Using first entry!\n";
+                  << fileName.c_str() << ". Using first entry.\n";
         return;
       }
     }

--- a/src/FFSetup.cpp
+++ b/src/FFSetup.cpp
@@ -389,6 +389,17 @@ void Dihedral::Read(Reader &param, std::string const &firstVar) {
 }
 void Dihedral::Add(std::string const &merged, const double coeff,
                    const uint index, const double def) {
+  // Check for (and skip) duplicate periodicities for the same dihedral
+  bool duplicate = false;
+  for (auto it = n[merged].begin(); it != n[merged].end(); ++it) {
+    duplicate |= *it == index;
+  }
+
+  if (duplicate) {
+    std::cout << "Warning: Skipping duplicate periodicity of " << index
+              << " for dihedral " << merged << "!\n";
+    return;
+  }
   ++countTerms;
   Kchi[merged].push_back(EnConvIfCHARMM(coeff));
   n[merged].push_back(index);

--- a/src/FFSetup.h
+++ b/src/FFSetup.h
@@ -40,7 +40,7 @@ public:
   std::string ReadKind(Reader &param, std::string const &firstKindName);
   std::vector<std::string> &getnamelist() { return name; }
 
-  bool validname(std::string &merged) {
+  bool validname(const std::string &merged) const {
     return (std::count(name.begin(), name.end(), merged) > 0);
   }
   std::string getname(const uint i) const { return name[i]; }

--- a/src/FFSetup.h
+++ b/src/FFSetup.h
@@ -146,8 +146,8 @@ class Dihedral : public ReadableBaseWithFirst, public FFBase {
 public:
   Dihedral(void) : FFBase(4, true), last(""), countTerms(0) {}
   virtual void Read(Reader &param, std::string const &firstVar);
-  void Add(std::string const &merged, const double coeff, const uint index,
-           const double def);
+  void Add(const std::string &fileName, const std::string &merged,
+           const double coeff, const uint index, const double def);
   uint getTerms() const { return countTerms; }
   uint append(std::string &s, double *Kchi_in, double *delta_in, uint *n_in,
               uint count) const {

--- a/src/Reader.h
+++ b/src/Reader.h
@@ -32,6 +32,7 @@ inline std::ifstream &operator>>(std::ifstream &is, bool &val) {
 
 class Reader {
 public:
+  friend inline std::ifstream &operator>>(std::ifstream &is, bool &val);
   Reader(std::string const &name, std::string const &alias,
          bool useSkipW = false, std::string const *const skipW = NULL,
          bool useSkipC = false, std::string const *const skipC = NULL,
@@ -98,6 +99,7 @@ public:
   }
 
   bool Read(std::string &firstItem);
+  std::string getFileName() const { return fileName; };
 
   // Make public to expose object.
   std::ifstream file;


### PR DESCRIPTION
Resolves issue #529 by issuing a warning when dihedrals with matching periodicities are found. The duplicates are removed and a warning is generated. The warning looks like this:

Warning: Skipping duplicate periodicity of 3 for dihedral HCCTCTHC!
