### PR TITLE
Terminate GOMC (with an error message) if the initial configuration has infinite energy

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -75,6 +75,14 @@ Simulation::~Simulation() {
 void Simulation::RunSimulation(void) {
   GOMC_EVENT_START(1, GomcProfileEvent::MC_RUN);
   double startEnergy = system->potential.totalEnergy.total;
+  if (!std::isfinite(startEnergy)) {
+    std::cout
+        << "Initial system has non-finite energy. This is usually caused"
+           " by two or more atoms in the initial configuration having "
+           "identical coordinates. Please correct your input file and rerun.\n";
+
+    exit(EXIT_FAILURE);
+  }
   if (totalSteps == 0) {
     for (int i = 0; i < (int)frameSteps.size(); i++) {
       if (i == 0) {


### PR DESCRIPTION
If the initial configuration is physically impossible, such as having two atoms in the same initial position, then GOMC will produce an initial energy that is infinite or NaN. For this case, the simulation won't self-correct to a feasible system. So, we should terminate with an error message so that the user can fix the initial configuration.

This patch introduces code to handle this situation.
