### PR TITLE
Recognize newer OpenMP version date codes

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -113,12 +113,12 @@ int main(int argc, char *argv[]) {
 #endif
     // Print OpenMP version if recognized or OpenMP date code if not recognized.
 #ifdef _OPENMP
-    std::unordered_map<unsigned, std::string> omp_map{
+    std::unordered_map<int, std::string> omp_map{
         {200505, "2.5"}, {200805, "3.0"}, {201107, "3.1"},
         {201307, "4.0"}, {201511, "4.5"}, {201611, "5.0 Preview 1"},
-        {201811, "5.0"}};
-    std::unordered_map<unsigned, std::string>::const_iterator match =
-        omp_map.find(_OPENMP);
+        {201811, "5.0"}, {202011, "5.1"}, {202111, "5.2"},
+        {202411, "6.0"}};
+    auto match = omp_map.find(_OPENMP);
     if (match == omp_map.end())
       printf("%-40s %u\n", "Info: Compiled with OpenMP Version", _OPENMP);
     else

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -111,13 +111,12 @@ int main(int argc, char *argv[]) {
 #if defined _OPENMP && _OPENMP < 201511
     printf("Warning: OpenMP version < 4.5. GOMC will not run optimally!\n");
 #endif
-    // Print OpenMP version if recognized or OpenMP date code if not recognized.
+    // Print the OpenMP version if recognized or instead the OpenMP date code.
 #ifdef _OPENMP
     std::unordered_map<int, std::string> omp_map{
-        {200505, "2.5"}, {200805, "3.0"}, {201107, "3.1"},
-        {201307, "4.0"}, {201511, "4.5"}, {201611, "5.0 Preview 1"},
-        {201811, "5.0"}, {202011, "5.1"}, {202111, "5.2"},
-        {202411, "6.0"}};
+        {200505, "2.5"}, {200805, "3.0"}, {201107, "3.1"}, {201307, "4.0"},
+        {201511, "4.5"}, {201611, "5.0 Preview 1"}, {201811, "5.0"},
+        {202011, "5.1"}, {202111, "5.2"}, {202411, "6.0"}};
     auto match = omp_map.find(_OPENMP);
     if (match == omp_map.end())
       printf("%-40s %u\n", "Info: Compiled with OpenMP Version", _OPENMP);


### PR DESCRIPTION
The GOMC output lists the current OpenMP version, such as 4.5, by mapping the OpenMP version date code to the OpenMP version. For instance, the date code 201511 corresponds to OpenMP version 4.5. This patch adds newer OpenMP date codes to the lookup table. Otherwise, the code prints out the date code instead of the corresponding version.